### PR TITLE
Add support for service annotations

### DIFF
--- a/charts/mageai/templates/service.yaml
+++ b/charts/mageai/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "mageai.fullname" . }}
   labels:
     {{- include "mageai.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -39,6 +39,8 @@ securityContext: {}
 service:
   type: NodePort
   port: 6789
+  # Annotations to add to the service
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
# Summary

Hope you appriciate a direct pull request. 
This PR adds support for adding custom service annotations.

# Tests

I have deployed the helm chart successfully on Azure, resulting in the service getting a private IP address.  
For the test I have used to following terraform code:
```tf
resource "helm_release" "mage" {
  name      = "mage"
  chart     = "/path/to/my/customized/charts/mageai"
  namespace = "mage"

  set {
    name  = "service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-internal"
    value = "true"
    type  = "string"
  }

  set {
    name  = "service.type"
    value = "LoadBalancer"
  }
}
```

cc: @wangxiaoyou1993 
