### PR TITLE
Remove latest tag, to prevent accidental upgrades

### DIFF
--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.3
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.2"
+appVersion: "0.9.11"

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: mageai/mageai
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag:
 
 imagePullSecrets: []
 nameOverride: "mageai"


### PR DESCRIPTION
Using a fixed tag is recommended to avoid accidental upgrades.

# Summary
As the `appVersion` is defined, we don't need to add a tag in values. I have removed the tag value.
In order to not accidentally downgrade some installations, I have updated the `appVersion` to the current latest `0.9.11`.

# Tests
- kubeconform
- chart-testing
- helm template -> Produces the correct tag `0.9.11

cc: @wangxiaoyou1993 
