### PR TITLE
More customisation options for Volumes

### DIFF
--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -48,8 +48,9 @@ spec:
           env:
             {{- toYaml .Values.env | nindent 12 }}
           volumeMounts:
-            - name: mage-fs
-              mountPath: /home/src
+          {{- if .Values.extraVolumeMounts -}}
+            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -62,7 +63,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.extraVolumes -}}
+        {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
           volumeMounts:
           {{- if .Values.extraVolumeMounts -}}
             {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- else if .Values.volumes }}
+            - name: mage-fs
+              mountPath: /home/src
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -66,4 +69,6 @@ spec:
       volumes:
       {{- if .Values.extraVolumes -}}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
+      {{- else if .Values.volumes }}
+        {{- toYaml .Values.volumes | nindent 8 }}
       {{- end }}

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -76,7 +76,11 @@ tolerations: []
 
 affinity: {}
 
-volumes:
+extraVolumeMounts:
+  - name: mage-fs
+    mountPath: /home/src
+
+extraVolumes:
   - name: mage-fs
     hostPath:
       path: /path/to/mage_project


### PR DESCRIPTION
Based on [feature request](https://mageai.slack.com/archives/C03KW780J2F/p1691344029730949)
# Summary
Currently the only possible volumeMount mountPath has been `/home/src`. In order to
- change the mount path
- add more volumes

I have changed the volume value to `extraVolumes` and `extraVolumeMounts` specification. The default values will still produce the same volume and mount as before.
The old `volumes` config is still supported, if `extraVolumes` is not configured.

# Tests
- chart-testing
- kubeconform
- helm template -> correct mounts

cc: @wangxiaoyou1993 
