### PR TITLE
Change Values service.type to LoadBalancer

### DIFF
--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -37,7 +37,7 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
-  type: NodePort
+  type: LoadBalancer
   port: 6789
   # Annotations to add to the service
   annotations: {}


### PR DESCRIPTION
This is me being nit-picky...

Based on [kube-score](https://github.com/zegl/kube-score): NodePort services should be avoided as they are insecure, and can not be used together with NetworkPolicies. LoadBalancers or use of an Ingress is recommended over NodePorts.

I believe any helm chart default values should be based on best practice.

# Summary
Changed the default value for service.type to `LoadBalancer`

# Tests
- chart-testing
- kubeconform
- kube-score
- tested on Docker Desktop Kubernetes

cc: @wangxiaoyou1993 
