### PR TITLE
Prevent premature restarts

### DIFF
--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -35,29 +35,33 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          {{ if .Values.livenessProbe.enabled | default true -}}
+          {{- if .Values.customLivenessProbe }}
+          livenessProbe: {{- toYaml .Values.customLivenessProbe | nindent 12 }}
+          {{- else if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.livenessProbe.path | default "/api/status" }}
-              port: {{ .Values.livenessProbe.port | default "http" }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 5 }}
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             terminationGracePeriodSeconds: {{ .Values.livenessProbe.terminationGracePeriodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 1 }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           {{- end }}
-          {{ if .Values.readinessProbe.enabled | default true -}}
+          {{- if .Values.customReadinessProbe }}
+          readinessProbe: {{- toYaml .Values.customReadinessProbe | nindent 12 }}
+          {{- else if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.readinessProbe.path | default "/api/status" }}
-              port: {{ .Values.readinessProbe.port | default "http" }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 5 }}
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             terminationGracePeriodSeconds: {{ .Values.readinessProbe.terminationGracePeriodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -35,14 +35,28 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{ if .Values.livenessProbe -}}
           livenessProbe:
             httpGet:
               path: /api/status
               port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            terminationGracePeriodSeconds: {{ .Values.livenessProbe.terminationGracePeriodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /api/status
               port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            terminationGracePeriodSeconds: {{ .Values.readinessProbe.terminationGracePeriodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -35,28 +35,30 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          {{ if .Values.livenessProbe -}}
+          {{ if .Values.livenessProbe.enabled | default true -}}
           livenessProbe:
             httpGet:
-              path: /api/status
-              port: http
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+              path: {{ .Values.livenessProbe.path | default "/api/status" }}
+              port: {{ .Values.livenessProbe.port | default "http" }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 5 }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             terminationGracePeriodSeconds: {{ .Values.livenessProbe.terminationGracePeriodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 1 }}
           {{- end }}
+          {{ if .Values.readinessProbe.enabled | default true -}}
           readinessProbe:
             httpGet:
-              path: /api/status
-              port: http
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+              path: {{ .Values.readinessProbe.path | default "/api/status" }}
+              port: {{ .Values.readinessProbe.port | default "http" }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 5 }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             terminationGracePeriodSeconds: {{ .Values.readinessProbe.terminationGracePeriodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -42,6 +42,14 @@ service:
   # Annotations to add to the service
   annotations: {}
 
+livenessProbe:
+  initialDelaySeconds: 5
+  timeoutSeconds: 10
+
+readinessProbe:
+  initialDelaySeconds: 5
+  timeoutSeconds: 1
+
 ingress:
   enabled: false
   className: ""

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -44,29 +44,35 @@ service:
 
 # Configure extra options for containers' liveness probes
 # If not configured, the probe is enabled using the following values
-livenessProbe: {}
-  # enabled: true
-  # path: /api/status
-  # port: http
-  # initialDelaySeconds: 5
+livenessProbe:
+  enabled: true
+  path: /api/status
+  port: http
+  initialDelaySeconds: 5
   # failureThreshold:
   # periodSeconds:
   # successThreshold:
   # terminationGracePeriodSeconds:
-  # timeoutSeconds: 10
+  timeoutSeconds: 10
 
 # Configure extra options for containers' readiness probes
 # If not configured, the probe is enabled using the following values
-readinessProbe: {}
-  # enabled: true
-  # path: /api/status
-  # port: http
-  # initialDelaySeconds: 5
+readinessProbe:
+  enabled: true
+  path: /api/status
+  port: http
+  initialDelaySeconds: 5
   # failureThreshold:
   # periodSeconds:
   # successThreshold:
   # terminationGracePeriodSeconds:
-  # timeoutSeconds: 1
+  timeoutSeconds: 1
+
+# Custom liveness probe
+customLivenessProbe: {}
+
+# Custom rediness probe
+customReadinessProbe: {}
 
 ingress:
   enabled: false

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -42,13 +42,31 @@ service:
   # Annotations to add to the service
   annotations: {}
 
-livenessProbe:
-  initialDelaySeconds: 5
-  timeoutSeconds: 10
+# Configure extra options for containers' liveness probes
+# If not configured, the probe is enabled using the following values
+livenessProbe: {}
+  # enabled: true
+  # path: /api/status
+  # port: http
+  # initialDelaySeconds: 5
+  # failureThreshold:
+  # periodSeconds:
+  # successThreshold:
+  # terminationGracePeriodSeconds:
+  # timeoutSeconds: 10
 
-readinessProbe:
-  initialDelaySeconds: 5
-  timeoutSeconds: 1
+# Configure extra options for containers' readiness probes
+# If not configured, the probe is enabled using the following values
+readinessProbe: {}
+  # enabled: true
+  # path: /api/status
+  # port: http
+  # initialDelaySeconds: 5
+  # failureThreshold:
+  # periodSeconds:
+  # successThreshold:
+  # terminationGracePeriodSeconds:
+  # timeoutSeconds: 1
 
 ingress:
   enabled: false


### PR DESCRIPTION
# Summary
Adds possibility to configure `readinessProbe` and `livenessProbe`.
Also removes `livenessProbe` if not configured. Rather have no `livenessProbe` than a poorly configured one. A poorly configured `livenessProbe` will trigger a premature restart of the container. The default parameters by kubernetes are:

> - `initialDelaySeconds`: Number of seconds after the container has started before startup, liveness or readiness probes are initiated. If a startup probe is defined, liveness and readiness probe delays do not begin until the startup probe has succeeded. Defaults to 0 seconds. Minimum value is 0.
> - `periodSeconds`: How often (in seconds) to perform the probe. Default to 10 seconds. The minimum value is 1.
> - `timeoutSeconds`: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
> - `successThreshold`: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup Probes. Minimum value is 1.
> - `failureThreshold`: After a probe fails `failureThreshold` times in a row, Kubernetes considers that the overall check has failed: the container is not ready/healthy/live. For the case of a startup or liveness probe, if at least `failureThreshold` probes have failed, Kubernetes treats the container as unhealthy and triggers a restart for that specific container. The kubelet honors the setting of `terminationGracePeriodSeconds` for that container. For a failed readiness probe, the kubelet continues running the container that failed checks, and also continues to run more probes; because the check failed, the kubelet sets the `Ready` [condition](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions) on the Pod to `false`.
> - `terminationGracePeriodSeconds`: configure a grace period for the kubelet to wait between triggering a shut down of the failed container, and then forcing the container runtime to stop that container. The default is to inherit the Pod-level value for `terminationGracePeriodSeconds` (30 seconds if not specified), and the minimum value is 1. See [probe-level terminationGracePeriodSeconds](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#probe-level-terminationgraceperiodseconds) for more detail.

The current `livenessProbe` would trigger a restart if a single test would timeout after 1 sec. This is quite common for standalone single node deployments. Therefore I have set the new default value for the `livenessProbe.timeoutSeconds` to 10 seconds.

# Tests
- kubeconform
- kube-score -> Still complaining about having the same `readinessProbe` and `livenessProbe`. The recommendation is to have a own api path, which checks for readiness (e.g. backend db loaded/migrated, ...)
  - Raised a feature request, which is now on the [roadmap](https://airtable.com/shrJctaGt4tvU27uF/tbl5bIlFkk2KhCpL4/viwuG2UltYNwgKTVC/recjUTSmfh7jZqeoe)
- chart-testing
- deployed on docker desktop kubernetes

cc: @wangxiaoyou1993 
