### PR TITLE
Add configmap and secrets as env variables

### DIFF
--- a/charts/mageai/templates/_helpers.tpl
+++ b/charts/mageai/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate chart secret name
+*/}}
+{{- define "mageai.secretName" -}}
+{{ default (printf "%s-secert-env" (include "mageai.fullname" .)) .Values.existingSecret }}
+{{- end -}}

--- a/charts/mageai/templates/_helpers.tpl
+++ b/charts/mageai/templates/_helpers.tpl
@@ -65,5 +65,5 @@ Create the name of the service account to use
 Generate chart secret name
 */}}
 {{- define "mageai.secretName" -}}
-{{ default (printf "%s-secert-env" (include "mageai.fullname" .)) .Values.existingSecret }}
+{{ default (printf "%s-secret-env" (include "mageai.fullname" .)) .Values.existingSecret }}
 {{- end -}}

--- a/charts/mageai/templates/configmap.yaml
+++ b/charts/mageai/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mageai.fullname" . }}-env
+  labels:
+    {{- include "mageai.labels" . | nindent 4 }}
+data:
+  {{ toYaml .Values.config | indent 2 }}

--- a/charts/mageai/templates/configmap.yaml
+++ b/charts/mageai/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
     {{- include "mageai.labels" . | nindent 4 }}
 data:
   {{ toYaml .Values.config | indent 2 }}
+{{ end }}

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -45,8 +45,17 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ template "mageai.fullname" . }}-env
+            - secretRef:
+                name: {{ template "mageai.secretName" . }}
           env:
+          {{- if .Values.extraEnvs -}}
+            {{- toYaml .Values.extraEnvs | nindent 12 }}
+          {{- else if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           volumeMounts:
           {{- if .Values.extraVolumeMounts -}}
             {{ toYaml .Values.extraVolumeMounts | nindent 12 }}

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -46,8 +46,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
+            {{- if .Values.config }}
             - configMapRef:
-                name: {{ template "mageai.fullname" . }}-env
+                name: {{ include "mageai.fullname" . }}-env
+            {{- end }}
             - secretRef:
                 name: {{ template "mageai.secretName" . }}
           env:

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -50,8 +50,10 @@ spec:
             - configMapRef:
                 name: {{ include "mageai.fullname" . }}-env
             {{- end }}
+            {{- if or (.Values.existingSecret) (.Values.secrets) }}
             - secretRef:
-                name: {{ template "mageai.secretName" . }}
+                name: {{ include "mageai.secretName" . }}
+            {{- end }}
           env:
           {{- if .Values.extraEnvs -}}
             {{- toYaml .Values.extraEnvs | nindent 12 }}

--- a/charts/mageai/templates/secrets.yaml
+++ b/charts/mageai/templates/secrets.yaml
@@ -1,0 +1,11 @@
+{{ if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "mageai.fullname" . }}-secert-env
+  labels:
+    {{- include "mageai.labels" . | nindent 4 }}
+stringData:
+  {{ toYaml .Values.secrets | indent 2 }}
+{{ end }}

--- a/charts/mageai/templates/secrets.yaml
+++ b/charts/mageai/templates/secrets.yaml
@@ -1,9 +1,9 @@
-{{ if not .Values.existingSecret }}
+{{ if and (not .Values.existingSecret) (.Values.secrets) }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ include "mageai.fullname" . }}-secert-env
+  name: {{ include "mageai.secretName" . }}
   labels:
     {{- include "mageai.labels" . | nindent 4 }}
 stringData:

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -85,7 +85,18 @@ extraVolumes:
     hostPath:
       path: /path/to/mage_project
 
-env:
+# config: Default configuration for mageai as environment variables. These get injected directly in the container.
+config: {}
+
+# existingSecret: Spcifies an existing secret to be used as environment variables. These get injected directly in the container.
+existingSecret: ""
+
+# secrets: Default secrets for mageai as environment variables. These get injected directly in the container.
+# Consider using a secret manager first, before sourcing secrets as environment variables.
+secrets: {}
+
+# extraEnvs: Extra environment variables
+extraEnvs:
   - name: KUBE_NAMESPACE
     valueFrom:
       fieldRef:


### PR DESCRIPTION
# Summary
Mage has quite a lof of possible environment variables. To organise them, I like to put them into a configmap. This configmap is then used as environment variables.

Same goes for secrets. I also added a hint, to use a secret manager if possible.

Old env config is still possible -> minor change

# Tests
- chart-testing
- kubeconform
- helm template -> manual check
- deployed on Docker Desktop Kubernetes and checked whether the env variables are actually sourced

cc: @wangxiaoyou1993 