### PR TITLE
Add type hint for image.tag

### DIFF
--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: mageai/mageai
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag:
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: "mageai"


### PR DESCRIPTION
# Summary
Forgot to put the type hint `""` to `image.tag` after removing `latest`

# Tests
- kubeconform
- chart-testing
- helm template -> manual check whether it still shows the `appVersion` as `image.tag` if not configured in values

cc: @wangxiaoyou1993 