### PR TITLE
Prefix job-manager with fullname

### DIFF
--- a/charts/mageai/templates/serviceaccount.yaml
+++ b/charts/mageai/templates/serviceaccount.yaml
@@ -15,7 +15,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: job-manager
+  name: {{ include "mageai.fullname" . }}-job-manager
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
@@ -28,11 +28,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: mage-job-manager
+  name: {{ include "mageai.fullname" . }}-job-manager
 subjects:
 - kind: ServiceAccount
   name: {{ include "mageai.serviceAccountName" . }}
 roleRef:
   kind: Role # This must be Role or ClusterRole
-  name: job-manager # This must match the name of the Role or ClusterRole you wish to bind to
+  name: {{ include "mageai.fullname" . }}-job-manager # This must match the name of the Role or ClusterRole you wish to bind to
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# Summary
Changed the name of the role and role binding to use `{{ include "mageai.fullname" . }}` as prefix.
This is more in line with the naming of the rest of the resources, which are all prefixed with or named by `{{ include "mageai.fullname" . }}`

# Tests
- chart-testing
- kubeconform
- helm template -> manual check
- deployed on Docker Desktop Kubernetes

cc: @wangxiaoyou1993 
