### PR TITLE
Add workspace manager role

### DIFF
--- a/charts/mageai/templates/serviceaccount.yaml
+++ b/charts/mageai/templates/serviceaccount.yaml
@@ -36,3 +36,26 @@ roleRef:
   kind: Role # This must be Role or ClusterRole
   name: job-manager # This must match the name of the Role or ClusterRole you wish to bind to
   apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mageai.fullname" . }}-workspace-manager
+rules:
+- apiGroups: ["", "apps"] # "" indicates the core API group
+  resources: ["nodes", "persistentvolumeclaims", "services", "statefulsets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mageai.fullname" . }}-workspace-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "mageai.serviceAccountName" . }}
+roleRef:
+  kind: Role # This must be Role or ClusterRole
+  name: {{ include "mageai.fullname" . }}-workspace-manager # This must match the name of the Role or ClusterRole you wish to bind to
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Resolves #6 
# Summary
Adds workspace manager role, based on [documented](https://docs.mage.ai/developing-in-the-cloud/workspaces/kubernetes) role definition.
# Tests
- chart-testing
- kubeconform
- helm template -> manual check
- deployed on Docker Desktop Kubernetes -> service, pvc, statefulset, pod are created

cc: @wangxiaoyou1993