### PR TITLE
Bump App Version to 0.9.16

### DIFF
--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.3
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.11"
+appVersion: "0.9.16"


### PR DESCRIPTION
# Summary
Bump App Version to current latest: 0.9.16

# Tests
Deployed to Docker Desktop Kubernetes

cc: @wangxiaoyou1993 
