### PR TITLE
Add .gitattributes & .gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*          text=auto
+*.sh       text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Helm
+# Chart dependencies
+*.tgz


### PR DESCRIPTION
# Summary
Im working on Windows, therefore normalizing `*.sh` to `LF` in the working directory is needed in order to correctly build docker images.

Also when creating a helm package locally, we need to prevent the package from being commited.

# Tests
Manual check, whether .gitattributes and .gitignore take affect

cc: @wangxiaoyou1993 
