### PR TITLE
[xy] Bump version to 0.1.4 and make configs backward compatible.

### DIFF
--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -35,4 +35,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -75,17 +75,17 @@ spec:
                 name: {{ include "mageai.secretName" . }}
             {{- end }}
           env:
-          {{- if .Values.extraEnvs -}}
-            {{- toYaml .Values.extraEnvs | nindent 12 }}
-          {{- else if .Values.env }}
+          {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
+          {{- else if .Values.extraEnvs }}
+            {{- toYaml .Values.extraEnvs | nindent 12 }}
           {{- end }}
           volumeMounts:
-          {{- if .Values.extraVolumeMounts -}}
-            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
-          {{- else if .Values.volumes }}
+          {{- if .Values.volumes }}
             - name: mage-fs
               mountPath: /home/src
+          {{- else if .Values.extraVolumeMounts }}
+            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -100,8 +100,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-      {{- if .Values.extraVolumes -}}
-        {{ toYaml .Values.extraVolumes | nindent 8 }}
-      {{- else if .Values.volumes }}
+      {{- if .Values.volumes }}
         {{- toYaml .Values.volumes | nindent 8 }}
+      {{- else if .Values.extraVolumes -}}
+        {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
             - name: mage-fs
               mountPath: /home/src
           {{- else if .Values.extraVolumeMounts }}
-            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Bump version to 0.1.4 and make configs backward compatible.

The old values.yml uses `env` and `volumes`. The new values.yml uses `extraEnvs` and `extraVolumes`.

# Tests
<!-- How did you test your change? -->
Tested install helm chart with old values.yaml and new values.yml

cc:
<!-- Optionally mention someone to let them know about this pull request -->
