### PR TITLE
serviceaccount: enable ingress control

### DIFF
--- a/charts/mageai/templates/serviceaccount.yaml
+++ b/charts/mageai/templates/serviceaccount.yaml
@@ -43,8 +43,8 @@ kind: Role
 metadata:
   name: {{ include "mageai.fullname" . }}-workspace-manager
 rules:
-- apiGroups: ["", "apps"] # "" indicates the core API group
-  resources: ["nodes", "persistentvolumeclaims", "services", "statefulsets"]
+- apiGroups: ["", "networking.k8s.io", "apps"] # "" indicates the core API group
+  resources: ["nodes", "persistentvolumeclaims", "services", "statefulsets", "ingresses"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---


### PR DESCRIPTION

# Summary
Workspace manager has an option to add routes to existing ingresses, which requires explicit permissions.

# Tests
Use modified helm chart to deploy on K8 cluster on AWS. Verified additional routes can be added to an existing ingress.


