### PR TITLE
Redis support

### DIFF
--- a/charts/mageai/Chart.lock
+++ b/charts/mageai/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 18.1.1
+digest: sha256:79d2d6d43f93313876bfd130ef9b5908377fde03b01819759daff0a82c7afdc7
+generated: "2023-10-01T14:08:47.871298+05:30"

--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -18,6 +18,11 @@ maintainers:
     email: eng@mage.ai
 
 name: mageai
+dependencies:
+  - name: redis
+    version: 18.1.1
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
 
 
 sources:

--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -18,6 +18,12 @@ maintainers:
     email: eng@mage.ai
 
 name: mageai
+dependencies:
+  - name: redis
+    version: 18.1.1
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
+
 
 sources:
 - https://github.com/mage-ai/helm-charts/tree/master/charts/mageai

--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -18,11 +18,6 @@ maintainers:
     email: eng@mage.ai
 
 name: mageai
-dependencies:
-  - name: redis
-    version: 18.1.1
-    repository: https://charts.bitnami.com/bitnami
-    condition: redis.enabled
 
 
 sources:

--- a/charts/mageai/requirements.yaml
+++ b/charts/mageai/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  - name: redis
-    version: 18.1.1
-    repository: https://charts.bitnami.com/bitnami
-    condition: redis.enabled

--- a/charts/mageai/requirements.yaml
+++ b/charts/mageai/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: redis
+    version: 18.1.1
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled

--- a/charts/mageai/templates/_helpers.tpl
+++ b/charts/mageai/templates/_helpers.tpl
@@ -50,6 +50,16 @@ app.kubernetes.io/name: {{ include "mageai.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+
+{{/*
+Scheduler Selector labels
+*/}}
+{{- define "mageai.schedulerSelectorLabels" -}}
+app.kubernetes.io/name: {{ .Values.scheduler.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
 {{/*
 Create the name of the service account to use
 */}}

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.seperateScheduler }}
+{{- if not .Values.standaloneScheduler }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       serviceAccountName: {{ include "mageai.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
       initContainers:
         - name: wait-for-redis
           image: alpine
@@ -33,11 +34,12 @@ spec:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
               value: redis://{{.Release.Name}}-redis-headless:6379/0
-          {{- else if .Values.redis.url }}
+          {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
-              value: {{ .Values.redis.url }}
+              value: {{ .Values.redis.customRedisURL }}
           {{- end }}
           command: ["sh", "-c", "until nc -z -v $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f1) $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f2); do sleep 1; done"]
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -95,10 +97,10 @@ spec:
           {{- end }}
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://{{.Release.Name}}-redis-headless:6379/0
-          {{- else if .Values.redis.url}}
+              value: redis://{{ .Release.Name }}-redis-headless:6379/0
+          {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
-              value: {{.Values.redis.url}}
+              value: {{ .Values.redis.customRedisURL }}
           {{- end }}
           volumeMounts:
           {{- if .Values.volumes }}

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           env:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://mage-chart-redis-headless:6379/0
+              value: redis://{{.Release.Name}}-redis-headless:6379/0
           {{- else if .Values.redis.url }}
             - name: REDIS_URL
               value: {{ .Values.redis.url }}
@@ -95,7 +95,7 @@ spec:
           {{- end }}
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://mage-chart-redis-headless:6379/0
+              value: redis://{{.Release.Name}}-redis-headless:6379/0
           {{- else if .Values.redis.url}}
             - name: REDIS_URL
               value: {{.Values.redis.url}}

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -33,9 +33,9 @@ spec:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
               value: redis://mage-chart-redis-headless:6379/0
-          {{- else if .Values.redis.url}}
+          {{- else if .Values.redis.url }}
             - name: REDIS_URL
-              values: {{.Values.redis.url}}
+              value: {{ .Values.redis.url }}
           {{- end }}
           command: ["sh", "-c", "until nc -z -v $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f1) $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f2); do sleep 1; done"]
       containers:
@@ -98,7 +98,7 @@ spec:
               value: redis://mage-chart-redis-headless:6379/0
           {{- else if .Values.redis.url}}
             - name: REDIS_URL
-              values: {{.Values.redis.url}}
+              value: {{.Values.redis.url}}
           {{- end }}
           volumeMounts:
           {{- if .Values.volumes }}

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.seperateScheduler }}
+{{- if .Values.seperateScheduler }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "mageai.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.scheduler.replicaCount }}
   selector:
     matchLabels:
       {{- include "mageai.selectorLabels" . | nindent 6 }}

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -48,34 +48,6 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          {{- if .Values.customLivenessProbe }}
-          livenessProbe: {{- toYaml .Values.customLivenessProbe | nindent 12 }}
-          {{- else if .Values.livenessProbe.enabled }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.livenessProbe.path }}
-              port: {{ .Values.livenessProbe.port }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            successThreshold: {{ .Values.livenessProbe.successThreshold }}
-            terminationGracePeriodSeconds: {{ .Values.livenessProbe.terminationGracePeriodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          {{- end }}
-          {{- if .Values.customReadinessProbe }}
-          readinessProbe: {{- toYaml .Values.customReadinessProbe | nindent 12 }}
-          {{- else if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.readinessProbe.path }}
-              port: {{ .Values.readinessProbe.port }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            terminationGracePeriodSeconds: {{ .Values.readinessProbe.terminationGracePeriodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -26,18 +26,20 @@ spec:
       serviceAccountName: {{ include "mageai.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
       initContainers:
         - name: wait-for-redis
           image: alpine
           env:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://{{.Release.Name }}-redis-headless:6379/0
-          {{- else if .Values.redis.url }}
+              value: redis://{{ .Release.Name }}-redis-headless:6379/0
+          {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
-              value: {{ .Values.redis.url }}
+              value: {{ .Values.redis.customRedisURL }}
           {{- end }}
           command: ["sh", "-c", "until nc -z -v $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f1) $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f2); do sleep 1; done"]
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -67,10 +69,10 @@ spec:
           {{- end }}
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://{{.Release.Name}}-redis-headless:6379/0
-          {{- else if .Values.redis.url}}
+              value: redis://{{ .Release.Name }}-redis-headless:6379/0
+          {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
-              value: {{ .Values.redis.url }}
+              value: {{ .Values.redis.customRedisURL }}
           {{- end }}
           volumeMounts:
           {{- if .Values.volumes }}

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -32,7 +32,7 @@ spec:
           env:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://mage-chart-redis-headless:6379/0
+              value: redis://{{.Release.Name }}-redis-headless:6379/0
           {{- else if .Values.redis.url }}
             - name: REDIS_URL
               value: {{ .Values.redis.url }}
@@ -95,7 +95,7 @@ spec:
           {{- end }}
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://mage-chart-redis-headless:6379/0
+              value: redis://{{.Release.Name}}-redis-headless:6379/0
           {{- else if .Values.redis.url}}
             - name: REDIS_URL
               value: {{ .Values.redis.url }}

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.seperateScheduler }}
+{{- if .Values.standaloneScheduler }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -2,14 +2,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "mageai.fullname" . }}
+  name: {{ .Values.scheduler.name }}
   labels:
     {{- include "mageai.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.scheduler.replicaCount }}
   selector:
     matchLabels:
-      {{- include "mageai.selectorLabels" . | nindent 6 }}
+      {{- include "mageai.schedulerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -17,7 +17,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "mageai.selectorLabels" . | nindent 8 }}
+        {{- include "mageai.schedulerSelectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -33,9 +33,9 @@ spec:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
               value: redis://mage-chart-redis-headless:6379/0
-          {{- else if .Values.redis.url}}
+          {{- else if .Values.redis.url }}
             - name: REDIS_URL
-              values: {{.Values.redis.url}}
+              value: {{ .Values.redis.url }}
           {{- end }}
           command: ["sh", "-c", "until nc -z -v $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f1) $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f2); do sleep 1; done"]
       containers:
@@ -98,7 +98,7 @@ spec:
               value: redis://mage-chart-redis-headless:6379/0
           {{- else if .Values.redis.url}}
             - name: REDIS_URL
-              values: {{.Values.redis.url}}
+              value: {{ .Values.redis.url }}
           {{- end }}
           volumeMounts:
           {{- if .Values.volumes }}

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -2,11 +2,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "mageai.fullname" . }}
+  name: {{ .Values.webServer.name }}
   labels:
     {{- include "mageai.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.webService.replicaCount }}
+  replicas: {{ .Values.webServer.replicaCount }}
   selector:
     matchLabels:
       {{- include "mageai.selectorLabels" . | nindent 6 }}
@@ -33,9 +33,9 @@ spec:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
               value: redis://mage-chart-redis-headless:6379/0
-          {{- else if .Values.redis.url}}
+          {{- else if .Values.redis.url }}
             - name: REDIS_URL
-              values: {{.Values.redis.url}}
+              value: {{ .Values.redis.url }}
           {{- end }}
           command: ["sh", "-c", "until nc -z -v $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f1) $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f2); do sleep 1; done"]
       containers:
@@ -98,7 +98,7 @@ spec:
               value: redis://redis://mage-chart-redis-headless:6379/0
           {{- else if .Values.redis.url}}
             - name: REDIS_URL
-              values: {{.Values.redis.url}}
+              value: {{ .Values.redis.url }}
           {{- end }}
           volumeMounts:
           {{- if .Values.volumes }}

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -26,18 +26,20 @@ spec:
       serviceAccountName: {{ include "mageai.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
       initContainers:
         - name: wait-for-redis
           image: alpine
           env:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://{{.Release.Name}}-redis-headless:6379/0
-          {{- else if .Values.redis.url }}
+              value: redis://{{ .Release.Name }}-redis-headless:6379/0
+          {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
-              value: {{ .Values.redis.url }}
+              value: {{ .Values.redis.customRedisURL }}
           {{- end }}
           command: ["sh", "-c", "until nc -z -v $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f1) $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f2); do sleep 1; done"]
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -96,9 +98,9 @@ spec:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
               value: redis://{{.Release.Name}}-redis-headless:6379/0
-          {{- else if .Values.redis.url}}
+          {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
-              value: {{ .Values.redis.url }}
+              value: {{ .Values.redis.customRedisURL }}
           {{- end }}
           volumeMounts:
           {{- if .Values.volumes }}

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.seperateScheduler }}
+{{- if .Values.seperateScheduler }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "mageai.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.webService.replicaCount }}
   selector:
     matchLabels:
       {{- include "mageai.selectorLabels" . | nindent 6 }}
@@ -95,7 +95,7 @@ spec:
           {{- end }}
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://mage-chart-redis-headless:6379/0
+              value: redis://redis://mage-chart-redis-headless:6379/0
           {{- else if .Values.redis.url}}
             - name: REDIS_URL
               values: {{.Values.redis.url}}

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -32,7 +32,7 @@ spec:
           env:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://mage-chart-redis-headless:6379/0
+              value: redis://{{.Release.Name}}-redis-headless:6379/0
           {{- else if .Values.redis.url }}
             - name: REDIS_URL
               value: {{ .Values.redis.url }}
@@ -95,7 +95,7 @@ spec:
           {{- end }}
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://redis://mage-chart-redis-headless:6379/0
+              value: redis://{{.Release.Name}}-redis-headless:6379/0
           {{- else if .Values.redis.url}}
             - name: REDIS_URL
               value: {{ .Values.redis.url }}

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.seperateScheduler }}
+{{- if .Values.standaloneScheduler }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -6,18 +6,18 @@ replicaCount: 1
 standaloneScheduler: true
 
 scheduler:
-  replicaCount: 1 #Effective if standaloneScheduler is true
+  replicaCount: 1 # Effective if standaloneScheduler is true
   name: mageai-scheduler
 webServer:
-  replicaCount: 1 #Effective if standaloneScheduler is true
+  replicaCount: 1 # Effective if standaloneScheduler is true
   name: mageai-webserver
 
 redis:
-  enabled: false #Enable redis if you want more replica
+  enabled: false # Enable redis if you want more replica
   architecture: standalone
   auth:
     enabled: false
-  #Your custom redis url (make sure redis.enabled is set to false)
+  # Your custom redis url (make sure redis.enabled is set to false)
   # url: redis://redis:6379/0
 
 image:

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -5,20 +5,24 @@
 replicaCount: 1
 standaloneScheduler: true
 
+# Effective if standaloneScheduler is true
 scheduler:
-  replicaCount: 1 # Effective if standaloneScheduler is true
+  replicaCount: 1
   name: mageai-scheduler
 
+
+# Effective if standaloneScheduler is true
 webServer:
-  replicaCount: 1 # Effective if standaloneScheduler is true
+  replicaCount: 1
   name: mageai-webserver
 
+# Enable redis if you want more replica
 redis:
-  enabled: false # Enable redis if you want more replicas
+  enabled: false
   architecture: standalone
   auth:
     enabled: false
-  # Your custom redis URL (make sure redis.enabled is set to false)
+  # Your custom redis url (make sure redis.enabled is set to false)
   # url: redis://redis:6379/0
 
 image:

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -47,15 +47,15 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext: {}
-# fsGroup: 2000
+  # fsGroup: 2000
 
 securityContext: {}
-# capabilities:
-#   drop:
-#   - ALL
-# readOnlyRootFilesystem: true
-# runAsNonRoot: true
-# runAsUser: 1000
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
 
 service:
   type: LoadBalancer
@@ -99,8 +99,8 @@ ingress:
   enabled: false
   className: ""
   annotations: {}
-  # kubernetes.io/ingress.class: nginx
-  # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
@@ -112,16 +112,16 @@ ingress:
   #      - chart-example.local
 
 resources: {}
-# We usually recommend not to specify default resources and to leave this as a conscious
-# choice for the user. This also increases chances charts run on environments with little
-# resources, such as Minikube. If you do want to specify resources, uncomment the following
-# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-# limits:
-#   cpu: 100m
-#   memory: 128Mi
-# requests:
-#   cpu: 100m
-#   memory: 128Mi
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
 nodeSelector: {}
 

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -8,16 +8,17 @@ standaloneScheduler: true
 scheduler:
   replicaCount: 1 # Effective if standaloneScheduler is true
   name: mageai-scheduler
+
 webServer:
   replicaCount: 1 # Effective if standaloneScheduler is true
   name: mageai-webserver
 
 redis:
-  enabled: false # Enable redis if you want more replica
+  enabled: false # Enable redis if you want more replicas
   architecture: standalone
   auth:
     enabled: false
-  # Your custom redis url (make sure redis.enabled is set to false)
+  # Your custom redis URL (make sure redis.enabled is set to false)
   # url: redis://redis:6379/0
 
 image:
@@ -42,15 +43,15 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
+# fsGroup: 2000
 
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
 
 service:
   type: LoadBalancer
@@ -87,15 +88,15 @@ readinessProbe:
 # Custom liveness probe
 customLivenessProbe: {}
 
-# Custom rediness probe
+# Custom readiness probe
 customReadinessProbe: {}
 
 ingress:
   enabled: false
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
@@ -107,16 +108,16 @@ ingress:
   #      - chart-example.local
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
 
 nodeSelector: {}
 
@@ -136,7 +137,7 @@ extraVolumes:
 # config: Default configuration for mageai as environment variables. These get injected directly in the container.
 config: {}
 
-# existingSecret: Spcifies an existing secret to be used as environment variables. These get injected directly in the container.
+# existingSecret: Specifies an existing secret to be used as environment variables. These get injected directly in the container.
 existingSecret: ""
 
 # secrets: Default secrets for mageai as environment variables. These get injected directly in the container.

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -6,14 +6,14 @@ replicaCount: 2
 seperateScheduler: true
 
 scheduler:
-  replicaCount: 1 #Effective if seperateScheduler is true
+  replicaCount: 2 #Effective if seperateScheduler is true
   name: mageai-scheduler
 webServer:
   replicaCount: 1 #Effective if seperateScheduler is true
   name: mageai-webserver
 
 redis:
-  enabled: false #Enable redis if you want more replica
+  enabled: true #Enable redis if you want more replica
   architecture: standalone
   auth:
     enabled: false

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -3,15 +3,17 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 2
-seperateScheduler: false
+seperateScheduler: true
 
 scheduler:
   replicaCount: 1 #Effective if seperateScheduler is true
-webService:
+  name: mageai-scheduler
+webServer:
   replicaCount: 1 #Effective if seperateScheduler is true
+  name: mageai-webserver
 
 redis:
-  enabled: true #Enable redis if you want more replica
+  enabled: false #Enable redis if you want more replica
   architecture: standalone
   auth:
     enabled: false

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -23,7 +23,7 @@ redis:
   auth:
     enabled: false
   # Your custom redis url (make sure redis.enabled is set to false)
-  # url: redis://redis:6379/0
+  customRedisURL: ""
 
 image:
   repository: mageai/mageai

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -2,7 +2,20 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
+seperateScheduler: false
+
+scheduler:
+  replicaCount: 1 #Effective if seperateScheduler is true
+webService:
+  replicaCount: 1 #Effective if seperateScheduler is true
+
+redis:
+  enabled: true #Enable redis if you want more replica
+  architecture: standalone
+  auth:
+    enabled: false
+  url: redis://redis:6379/0 #Your custom redis url (make sure redis.enabled is set to false)
 
 image:
   repository: mageai/mageai

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -2,22 +2,23 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 2
-seperateScheduler: true
+replicaCount: 1
+standaloneScheduler: true
 
 scheduler:
-  replicaCount: 2 #Effective if seperateScheduler is true
+  replicaCount: 1 #Effective if standaloneScheduler is true
   name: mageai-scheduler
 webServer:
-  replicaCount: 1 #Effective if seperateScheduler is true
+  replicaCount: 1 #Effective if standaloneScheduler is true
   name: mageai-webserver
 
 redis:
-  enabled: true #Enable redis if you want more replica
+  enabled: false #Enable redis if you want more replica
   architecture: standalone
   auth:
     enabled: false
-  url: redis://redis:6379/0 #Your custom redis url (make sure redis.enabled is set to false)
+  #Your custom redis url (make sure redis.enabled is set to false)
+  # url: redis://redis:6379/0
 
 image:
   repository: mageai/mageai


### PR DESCRIPTION
# Summary
Added Redis dependency to the chart to support multiple replicas
Standalone scheduler and webserver option added to the chart

# Tests
Deployed standalone mode with Redis enabled in the chart as well as external Redis URL - passed
Deployed multiple replicas with Redis enabled in the chart as well as external Redis URL - passed

# CC
@wangxiaoyou1993, @dy46, @johnson-mage, @tommydangerous