### PR TITLE
add support for non empty MAGE_BASE_PATH

### DIFF
--- a/charts/mageai/templates/_helpers.tpl
+++ b/charts/mageai/templates/_helpers.tpl
@@ -67,3 +67,16 @@ Generate chart secret name
 {{- define "mageai.secretName" -}}
 {{ default (printf "%s-secret-env" (include "mageai.fullname" .)) .Values.existingSecret }}
 {{- end -}}
+
+{{/*
+Base path
+*/}}
+{{- define "mageai.basePath" -}}
+{{- if .Values.extraEnvs }}
+{{- range .Values.extraEnvs }}
+{{- if eq .name "MAGE_BASE_PATH" }}
+{{- printf "/%s" .value }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mageai/templates/tests/test-connection.yaml
+++ b/charts/mageai/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "mageai.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "mageai.fullname" . }}:{{ .Values.service.port }}{{ include "mageai.basePath" . }}']
   restartPolicy: Never


### PR DESCRIPTION
# Summary
Helm test is currently failing when MAGE_BASE_PATH is used. Fix helm charts to include it in the route, if defined

# Tests
Manually tested with/without MAGE_BASE_PATH defined

