### PR TITLE
Update serviceaccount.yaml

### DIFF
--- a/charts/mageai/templates/serviceaccount.yaml
+++ b/charts/mageai/templates/serviceaccount.yaml
@@ -44,7 +44,7 @@ metadata:
   name: {{ include "mageai.fullname" . }}-workspace-manager
 rules:
 - apiGroups: ["", "networking.k8s.io", "apps"] # "" indicates the core API group
-  resources: ["nodes", "persistentvolumeclaims", "services", "statefulsets", "ingresses"]
+  resources: ["nodes", "persistentvolumeclaims", "services", "statefulsets", "ingresses", "configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---


### PR DESCRIPTION
Was getting 403 error creating new k8 pods where it attempts to delete the pre-start config: self.core_client.delete_namespaced_config_map(f'{name}-pre-start', self.namespace)

# Tests
mirrors what we did locally.

cc:
@dy46 