### PR TITLE
[xy] Updates on standalone scheduler configs

### DIFF
--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -74,6 +74,8 @@ spec:
             - name: REDIS_URL
               value: {{ .Values.redis.customRedisURL }}
           {{- end }}
+            - name: INSTANCE_TYPE
+              value: scheduler
           volumeMounts:
           {{- if .Values.volumes }}
             - name: mage-fs

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -102,6 +102,8 @@ spec:
             - name: REDIS_URL
               value: {{ .Values.redis.customRedisURL }}
           {{- end }}
+            - name: INSTANCE_TYPE
+              value: web_server
           volumeMounts:
           {{- if .Values.volumes }}
             - name: mage-fs

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
-standaloneScheduler: true
+standaloneScheduler: false
 
 # Effective if standaloneScheduler is true
 scheduler:


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
* Set default value of standaloneScheduler to false. (not break current default behaviour)
* Add instance type env var to scheduler and web server. Will update the Mage server code to get the instance type from env var if it exists

# Tests
<!-- How did you test your change? -->
- [x] Test standaloneScheduler: false.
- [x] Test standaloneScheduler: true with 2 web servers and 2 schedulers (redis enabled: false)
- [x] Test standaloneScheduler: true with 2 web servers and 2 schedulers (redis enabled: true)

cc:
<!-- Optionally mention someone to let them know about this pull request -->
