### PR TITLE
feat(sidecar): allow extraContainers in values.yaml to enable sidecar…

### DIFF
--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -35,7 +35,7 @@ apiVersion: v2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.44"
+appVersion: "0.9.55"
 
 description: A Helm chart for Mage AI
 
@@ -72,4 +72,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -109,6 +109,9 @@ spec:
           {{- else if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
+          {{- if .Values.extraContainers }}
+            {{- toYaml .Values.extraContainers | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
…s like CloudSQL proxy

# Summary
Sometimes it can be useful to run sidecars in the mageai deployment. The most pressing example for me is running CloudSQL proxy, which will allow me to authenticate using Kubernetes service accounts rather than username/password.

# Tests
helm template, validate manifests

cc:
@tommydangerous 