### PR TITLE
fix: fix configmap and secret

### DIFF
--- a/charts/mageai/templates/configmap.yaml
+++ b/charts/mageai/templates/configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "mageai.labels" . | nindent 4 }}
 data:
-  {{ toYaml .Values.config | indent 2 }}
+  {{- toYaml .Values.config | nindent 2 }}
 {{ end }}

--- a/charts/mageai/templates/secrets.yaml
+++ b/charts/mageai/templates/secrets.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     {{- include "mageai.labels" . | nindent 4 }}
 stringData:
-  {{ toYaml .Values.secrets | indent 2 }}
+  {{- toYaml .Values.secrets | nindent 2 }}
 {{ end }}


### PR DESCRIPTION
# Summary
- Fix configmap and secret template

# Tests

**configmap**
Run test template with `helm template -s templates/configmap.yaml --debug`

input:
```yaml
config:
  test: "test"
  test2: "test2"
```
output:
```yaml
---
# Source: mageai/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: mageai-env
  labels:
    helm.sh/chart: mageai-0.2.0
    app.kubernetes.io/name: mageai
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.9.55"
    app.kubernetes.io/managed-by: Helm
data:
  test: test
  test2: test2
```

**secret**

Run test template with `helm template -s templates/secrets.yaml --debug`
input:
```yaml
secret:
  secret: "1"
  secret2: "2"
```

output: 
```yaml
---
# Source: mageai/templates/secrets.yaml
apiVersion: v1
kind: Secret
type: Opaque
metadata:
  name: mageai-secret-env
  labels:
    helm.sh/chart: mageai-0.2.0
    app.kubernetes.io/name: mageai
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.9.55"
    app.kubernetes.io/managed-by: Helm
stringData:
  secret: "1"
  secret2: "2"
```

cc: 

N/A
