### PR TITLE
fix(containers): extraContainers need to be indented 8, not 12

### DIFF
--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -72,4 +72,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -109,9 +109,9 @@ spec:
           {{- else if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- if .Values.extraContainers }}
-            {{- toYaml .Values.extraContainers | nindent 12 }}
-          {{- end }}
+        {{- if .Values.extraContainers }}
+          {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
# Summary
Fix the thing I didn't do right yesterday - indent extraContainers 8 instead of 12.

# Tests
Verified that the yaml put the container at the right level.

cc:
@tommydangerous 