### PR TITLE
Allow specifying an image digest to deploy

### DIFF
--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -44,7 +44,11 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Allows setting `.Values.image.digest` in order to uniquely specify a particular image to deploy

# Tests
<!-- How did you test your change? -->
```helm lint```
and
```helm template -f values.yml ./charts/mageai > out.yml```
with the following `values.yml` file, trying all combinations of tag and digest enabled/disabled. I manually checked the output to confirm it looked as intended.
```
replicaCount: 1

image:
  repository: mageai/mageai
  pullPolicy: Always
  #tag: "0.9.56" # At least two images exist with this tag
  digest: "sha256:41be240147ca04d0954bb9544ac0675e86de78995cf739c2635ec398b43741cc"
```

Example output snippet:
```
          securityContext:
            {}
          image: "mageai/mageai@sha256:41be240147ca04d0954bb9544ac0675e86de78995cf739c2635ec398b43741cc"
          imagePullPolicy: Always
          ports:
            - name: http
```
