### PR TITLE
Scheduler and Webserver with separate resource configuration

### DIFF
--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -51,7 +51,7 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.scheduler.resources | nindent 12 }}
           envFrom:
             {{- if .Values.config }}
             - configMapRef:

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -51,7 +51,11 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           resources:
-            {{- toYaml .Values.scheduler.resources | nindent 12 }}
+            {{- if .Values.scheduler.resources }}
+              {{- toYaml .Values.scheduler.resources | nindent 12 }}
+            {{- else }}
+              {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
           envFrom:
             {{- if .Values.config }}
             - configMapRef:

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -79,7 +79,7 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.webServer.resources | nindent 12 }}
           envFrom:
             {{- if .Values.config }}
             - configMapRef:

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -79,7 +79,11 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           {{- end }}
           resources:
-            {{- toYaml .Values.webServer.resources | nindent 12 }}
+            {{- if .Values.webServer.resources }}
+              {{- toYaml .Values.webServer.resources | nindent 12 }}
+            {{- else }}
+              {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
           envFrom:
             {{- if .Values.config }}
             - configMapRef:

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -9,12 +9,34 @@ standaloneScheduler: false
 scheduler:
   replicaCount: 1
   name: mageai-scheduler
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 
 # Effective if standaloneScheduler is true
 webServer:
   replicaCount: 1
   name: mageai-webserver
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 # Enable redis if you want more replica
 redis:


### PR DESCRIPTION
# Summary
 Adding the resource configuration in values file let you deploy scheduler and webserver with different cpu and memory configurations

# Tests
 Deployed in local k8s cluster and verified that the custom resource configurations are working or not 

