### PR TITLE
[xy] Support horizontal pod scaler in deployment

### DIFF
--- a/charts/mageai/templates/hpa.yaml
+++ b/charts/mageai/templates/hpa.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.hpa -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: deployment-name-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "mageai.fullname" . }}
+  {{- toYaml .Values.hpa | nindent 2 }}
+{{- end }}

--- a/charts/mageai/templates/hpa.yaml
+++ b/charts/mageai/templates/hpa.yaml
@@ -1,12 +1,46 @@
+{{- if not .Values.standaloneScheduler }}
+
 {{- if .Values.hpa -}}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: deployment-name-hpa
+  name: {{ include "mageai.fullname" . }}-hpa
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "mageai.fullname" . }}
   {{- toYaml .Values.hpa | nindent 2 }}
+{{- end }}
+
+{{- else }}
+
+{{- if .Values.scheduler.hpa -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.scheduler.name }}-scheduler-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.scheduler.name }}
+  {{- toYaml .Values.scheduler.hpa | nindent 2 }}
+{{- end }}
+
+---
+
+{{- if .Values.webServer.hpa -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.webServer.name }}-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.webServer.name }}
+  {{- toYaml .Values.webServer.hpa | nindent 2 }}
+{{- end }}
+
 {{- end }}

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -117,6 +117,12 @@ customLivenessProbe: {}
 # Custom readiness probe
 customReadinessProbe: {}
 
+# Horizontal pod autoscaler
+# hpa:
+#   minReplicas: 1
+#   maxReplicas: 10
+#   targetCPUUtilizationPercentage: 50
+
 # We recommend creating the ingress separately instead of creating it using this chart.
 # There is a corresponding Mage-Ingress chart to create an ingress for Mage if needed.
 # This section is kept here for backwards compatibility.

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -20,7 +20,10 @@ scheduler:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
-
+  # hpa:
+  #   minReplicas: 1
+  #   maxReplicas: 10
+  #   targetCPUUtilizationPercentage: 50
 
 # Effective if standaloneScheduler is true
 webServer:
@@ -37,6 +40,10 @@ webServer:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  # hpa:
+  #   minReplicas: 1
+  #   maxReplicas: 10
+  #   targetCPUUtilizationPercentage: 50
 
 # Enable redis if you want more replica
 redis:


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Support horizontal pod scaler in deployment.

Example config in values.yaml
```
hpa:
  minReplicas: 1
  maxReplicas: 10
  targetCPUUtilizationPercentage: 50
```

# Tests
<!-- How did you test your change? -->
tested locally

<img width="682" alt="image" src="https://github.com/mage-ai/helm-charts/assets/80284865/b669d6f5-cbb2-4b6a-8e89-cefde1e29a10">


cc:
<!-- Optionally mention someone to let them know about this pull request -->
