### PR TITLE
service is always running on 6789 (cannot be changed)

### DIFF
--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: 6789
               protocol: TCP
           {{- if .Values.customLivenessProbe }}
           livenessProbe: {{- toYaml .Values.customLivenessProbe | nindent 12 }}


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
When updating the port of the load balancer the container port also gets updated but it is not possible to have mageai run on a different port than 6789.

# Tests
<!-- How did you test your change? -->
Deployed the helm chart and tested the connection from the Load Balancer

cc:
<!-- Optionally mention someone to let them know about this pull request -->
