### PR TITLE
Seperate affinity value per pod

### DIFF
--- a/charts/mageai/templates/deployment-scheduler.yaml
+++ b/charts/mageai/templates/deployment-scheduler.yaml
@@ -120,7 +120,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.scheduler.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/mageai/templates/deployment-scheduler.yaml
+++ b/charts/mageai/templates/deployment-scheduler.yaml
@@ -120,9 +120,11 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.scheduler.affinity }}
+      {{- if .Values.scheduler.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.scheduler.affinity | nindent 8 }}
+      {{- else }}
+        {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/charts/mageai/templates/deployment-standalone-scheduler.yaml
+++ b/charts/mageai/templates/deployment-standalone-scheduler.yaml
@@ -91,7 +91,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.scheduler.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/mageai/templates/deployment-standalone-scheduler.yaml
+++ b/charts/mageai/templates/deployment-standalone-scheduler.yaml
@@ -91,9 +91,11 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.scheduler.affinity }}
+      {{- if .Values.scheduler.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.scheduler.affinity | nindent 8 }}
+      {{- else }}
+        {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/charts/mageai/templates/deployment-webserver.yaml
+++ b/charts/mageai/templates/deployment-webserver.yaml
@@ -119,7 +119,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.webServer.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/mageai/templates/deployment-webserver.yaml
+++ b/charts/mageai/templates/deployment-webserver.yaml
@@ -119,9 +119,11 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.webServer.affinity }}
+      {{- if .Values.webServer.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.webServer.affinity | nindent 8 }}
+      {{- else }}
+        {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -25,6 +25,19 @@ scheduler:
   #   maxReplicas: 10
   #   targetCPUUtilizationPercentage: 50
 
+  # affinity for mageai-scheduler pod
+  affinity: {}
+  # affinity:
+  #   podAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #     - labelSelector:
+  #         matchExpressions:
+  #         - key: app.kubernetes.io/name
+  #           operator: In
+  #           values:
+  #           - mageai
+  #       topologyKey: "kubernetes.io/hostname"
+
 # Effective if standaloneScheduler is true
 webServer:
   replicaCount: 1
@@ -44,6 +57,19 @@ webServer:
   #   minReplicas: 1
   #   maxReplicas: 10
   #   targetCPUUtilizationPercentage: 50
+
+  # affinity for mageai-webserver pod
+  affinity: {}
+  # affinity:
+  #   podAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #     - labelSelector:
+  #         matchExpressions:
+  #         - key: app.kubernetes.io/name
+  #           operator: In
+  #           values:
+  #           - mageai-scheduler
+  #       topologyKey: "kubernetes.io/hostname"
 
 # Enable redis if you want more replica
 redis:
@@ -164,8 +190,6 @@ resources: {}
 nodeSelector: {}
 
 tolerations: []
-
-affinity: {}
 
 extraVolumeMounts:
   - name: mage-fs

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -191,6 +191,8 @@ nodeSelector: {}
 
 tolerations: []
 
+affinity: {}
+
 extraVolumeMounts:
   - name: mage-fs
     mountPath: /home/src


### PR DESCRIPTION
# Summary

- Divide `affinity` values per pod spec to improve template flexibility.
- Support backward compatibility
- **Similar case issue**
  - https://github.com/mage-ai/helm-charts/pull/45
  - https://github.com/mage-ai/helm-charts/pull/49

# Tests

- On my EKS v1.28 cluster, successfully deployed via argocd.

```console
$ kubectl get app -n argocd
NAME     SYNC STATUS   HEALTH STATUS
...
mageai   Synced        Degraded
```

cc: @wangxiaoyou1993 
<!-- Optionally mention someone to let them know about this pull request -->
