### PR TITLE
[xy] Add postgres as optional dependency and bump version to 0.2.5

### DIFF
--- a/charts/mageai/Chart.lock
+++ b/charts/mageai/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 15.5.15
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 18.1.1
-digest: sha256:79d2d6d43f93313876bfd130ef9b5908377fde03b01819759daff0a82c7afdc7
-generated: "2023-10-01T14:08:47.871298+05:30"
+digest: sha256:2fc0455e060a345ff3dea9d7ab4bc31983d71523a84df20dedb7bacaf5ade8bd
+generated: "2024-07-10T11:59:53.185421-07:00"

--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -35,7 +35,7 @@ apiVersion: v2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.70"
+appVersion: "0.9.72"
 
 description: A Helm chart for Mage AI
 
@@ -76,4 +76,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5

--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -50,6 +50,10 @@ maintainers:
 
 name: mageai
 dependencies:
+  - name: postgresql
+    version: 15.5.15
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
   - name: redis
     version: 18.1.1
     repository: https://charts.bitnami.com/bitnami

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -26,8 +26,9 @@ spec:
       serviceAccountName: {{ include "mageai.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
+      {{- if or .Values.redis.enabled .Values.redis.customRedisURL .Values.postgresql.enabled }}
       initContainers:
+        {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
         - name: wait-for-redis
           image: alpine
           env:
@@ -39,6 +40,12 @@ spec:
               value: {{ .Values.redis.customRedisURL }}
           {{- end }}
           command: ["sh", "-c", "until nc -z -v $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f1) $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f2); do sleep 1; done"]
+        {{- end }}
+        {{- if .Values.postgresql.enabled }}
+        - name: wait-for-postgres
+          image: busybox
+          command: ['sh', '-c', 'until nc -z {{ .Values.postgresql.fullnameOverride }} 5432; do echo waiting for postgres; sleep 2; done;']
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -105,6 +112,10 @@ spec:
           {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
               value: {{ .Values.redis.customRedisURL }}
+          {{- end }}
+          {{- if .Values.postgresql.enabled }}
+            - name: MAGE_DATABASE_CONNECTION_URL
+              value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Values.postgresql.fullnameOverride }}:5432/{{ .Values.postgresql.auth.database }}
           {{- end }}
           volumeMounts:
           {{- if .Values.volumes }}

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -26,19 +26,26 @@ spec:
       serviceAccountName: {{ include "mageai.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
+      {{- if or .Values.redis.enabled .Values.redis.customRedisURL .Values.postgresql.enabled }}
       initContainers:
+        {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
         - name: wait-for-redis
           image: alpine
           env:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://{{ .Release.Name }}-redis-headless:6379/0
+              value: redis://{{.Release.Name}}-redis-headless:6379/0
           {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
               value: {{ .Values.redis.customRedisURL }}
           {{- end }}
           command: ["sh", "-c", "until nc -z -v $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f1) $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f2); do sleep 1; done"]
+        {{- end }}
+        {{- if .Values.postgresql.enabled }}
+        - name: wait-for-postgres
+          image: busybox
+          command: ['sh', '-c', 'until nc -z {{ .Values.postgresql.fullnameOverride }} 5432; do echo waiting for postgres; sleep 2; done;']
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -77,6 +84,10 @@ spec:
           {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
               value: {{ .Values.redis.customRedisURL }}
+          {{- end }}
+          {{- if .Values.postgresql.enabled }}
+            - name: MAGE_DATABASE_CONNECTION_URL
+              value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Values.postgresql.fullnameOverride }}:5432/{{ .Values.postgresql.auth.database }}
           {{- end }}
             - name: INSTANCE_TYPE
               value: scheduler

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -26,19 +26,26 @@ spec:
       serviceAccountName: {{ include "mageai.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
+      {{- if or .Values.redis.enabled .Values.redis.customRedisURL .Values.postgresql.enabled }}
       initContainers:
+        {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
         - name: wait-for-redis
           image: alpine
           env:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: redis://{{ .Release.Name }}-redis-headless:6379/0
+              value: redis://{{.Release.Name}}-redis-headless:6379/0
           {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
               value: {{ .Values.redis.customRedisURL }}
           {{- end }}
           command: ["sh", "-c", "until nc -z -v $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f1) $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f2); do sleep 1; done"]
+        {{- end }}
+        {{- if .Values.postgresql.enabled }}
+        - name: wait-for-postgres
+          image: busybox
+          command: ['sh', '-c', 'until nc -z {{ .Values.postgresql.fullnameOverride }} 5432; do echo waiting for postgres; sleep 2; done;']
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -105,6 +112,10 @@ spec:
           {{- else if .Values.redis.customRedisURL }}
             - name: REDIS_URL
               value: {{ .Values.redis.customRedisURL }}
+          {{- end }}
+          {{- if .Values.postgresql.enabled }}
+            - name: MAGE_DATABASE_CONNECTION_URL
+              value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Values.postgresql.fullnameOverride }}:5432/{{ .Values.postgresql.auth.database }}
           {{- end }}
             - name: INSTANCE_TYPE
               value: web_server

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -45,6 +45,15 @@ webServer:
   #   maxReplicas: 10
   #   targetCPUUtilizationPercentage: 50
 
+# Enable Postgres as the DB
+postgresql:
+  enabled: false
+  fullnameOverride: "postgresql-service"
+  auth:
+    username: your_username
+    password: your_password
+    database: your_database
+
 # Enable redis if you want more replica
 redis:
   enabled: false


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Add postgres as optional dependency and bump version to 0.2.5

# Tests
<!-- How did you test your change? -->
Tested the following case
* set standalone scheduler to false
* set standalone scheduler to true
* set postgresql auth

notes: when reinstalling the helm chart, remember to manually delete the PVC created by the postgres service to get it cleaned up.

cc:
<!-- Optionally mention someone to let them know about this pull request -->
