### PR TITLE
Add deploymentAnnotations

### DIFF
--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -3,6 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mageai.fullname" . }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "mageai.labels" . | nindent 4 }}
 spec:

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -82,6 +82,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "mageai"
 
+deploymentAnnotations: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
# Summary
Since we use [Doppler Operator](https://docs.doppler.com/docs/kubernetes-operator) in our environment, we rely a lot on the Deployment annotations. At the moment, there are only `podAnnotations` so this PR extends the functionality

# Tests
Tested locally with our own Chart that is including `mageai` as as dependency, and we now can use the `deploymentAnnotations` properly

