### PR TITLE
Revert "update chart to us the last version of the deps"

### DIFF
--- a/charts/mageai/Chart.lock
+++ b/charts/mageai/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.0.1
+  version: 15.5.15
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 20.2.0
-digest: sha256:f6a940371cb351dd64d7c63530793e4e8bcfc92b4100889e306e7421fad9c592
-generated: "2024-10-09T22:28:39.43128+02:00"
+  version: 18.1.1
+digest: sha256:2fc0455e060a345ff3dea9d7ab4bc31983d71523a84df20dedb7bacaf5ade8bd
+generated: "2024-07-10T11:59:53.185421-07:00"

--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/images: |
     - name: mageai
-      image: mageai/mageai:0.9.44
+      image: mageai/mageai:0.9.74
       platforms:
         - linux/amd64
         - linux/arm64
@@ -35,7 +35,7 @@ apiVersion: v2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.72"
+appVersion: "0.9.74"
 
 description: A Helm chart for Mage AI
 
@@ -76,4 +76,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8

--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/images: |
     - name: mageai
-      image: mageai/mageai:0.9.74
+      image: mageai/mageai:0.9.44
       platforms:
         - linux/amd64
         - linux/arm64
@@ -35,7 +35,7 @@ apiVersion: v2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.74"
+appVersion: "0.9.72"
 
 description: A Helm chart for Mage AI
 
@@ -51,11 +51,11 @@ maintainers:
 name: mageai
 dependencies:
   - name: postgresql
-    version: 16.0.1
+    version: 15.5.15
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: redis
-    version: 20.2.0
+    version: 18.1.1
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
 


### PR DESCRIPTION
Reverts mage-ai/helm-charts#64

Revet since upgrading the postgres is a breaking change 
<img width="1058" alt="image" src="https://github.com/user-attachments/assets/33699b66-61c2-443d-83fc-daa8a026d464" />
