### PR TITLE
[xy] Add optional cli args to cleanup jobs and bump version to 0.2.9

### DIFF
--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -76,4 +76,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.2.9

--- a/charts/mageai/templates/cleanup-cronjob.yaml
+++ b/charts/mageai/templates/cleanup-cronjob.yaml
@@ -21,8 +21,8 @@ spec:
                 - -c
                 - |
                   repo_name="${USER_CODE_PATH:-default_repo}" &&
-                  mage clean-cached-variables "$repo_name" &&
-                  mage clean-old-logs "$repo_name"
+                  mage clean-cached-variables "$repo_name" {{.Values.cleanupJob.clean_variable_cli_args | default ""}} &&
+                  mage clean-old-logs "$repo_name" {{.Values.cleanupJob.clean_log_cli_args | default ""}}
               env:
               {{- if .Values.env }}
                 {{- toYaml .Values.env | nindent 16 }}

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -212,3 +212,5 @@ extraEnvs:
 
 cleanupJob:
   enabled: false
+  clean_variable_cli_args: ""
+  clean_log_cli_args: ""


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Add optional cli args to cleanup jobs and bump version to 0.2.9

# Tests
<!-- How did you test your change? -->
tested on pro cluster with config
<img width="522" alt="image" src="https://github.com/user-attachments/assets/20ba55ae-6b53-407e-a4ff-984a8e1c620e" />
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/4af23061-7d6c-4bc3-90ae-e3fde3ef0a21" />

cc: @tommydangerous @johnson-mage 
<!-- Optionally mention someone to let them know about this pull request -->
