### PR TITLE
Allow users to define the schedule for the cleanup job

### DIFF
--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -76,4 +76,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.9
+version: 0.2.10

--- a/charts/mageai/templates/cleanup-cronjob.yaml
+++ b/charts/mageai/templates/cleanup-cronjob.yaml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: {{ include "mageai.fullname" . }}-cleanup-job
 spec:
-  schedule: {{ .Values.cleanupJob.schedule_cron | default "0 * * * *" }}
+  schedule: {{ .Values.cleanupJob.schedule_cron | default "0 * * * *" | quote }}
   jobTemplate:
     spec:
       template:

--- a/charts/mageai/templates/cleanup-cronjob.yaml
+++ b/charts/mageai/templates/cleanup-cronjob.yaml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: {{ include "mageai.fullname" . }}-cleanup-job
 spec:
-  schedule: "0 * * * *"  # Runs every hour
+  schedule: {{ .Values.cleanupJob.schedule_cron | default "0 * * * *" }}
   jobTemplate:
     spec:
       template:

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -214,3 +214,4 @@ cleanupJob:
   enabled: false
   clean_variable_cli_args: ""
   clean_log_cli_args: ""
+  schedule_cron: "0 * * * *"  # Runs every hour


### PR DESCRIPTION
# Summary
Give control to the user to define the best schedule to clean up the variables and the logs.
The default value will be once per hour, it was the default value before this PR.

Bump version to `0.2.10`

cc: @tommydangerous 

# Testing

First I installed the `minikube` to have a local env to test the helm install.

## First test

I changed the values.yaml to have schedule define:
```yaml
cleanupJob:
  enabled: true
  clean_variable_cli_args: ""
  clean_log_cli_args: ""
  schedule_cron: "* * * * *"
```
<img width="1467" alt="Screenshot 2025-01-28 at 09 38 26" src="https://github.com/user-attachments/assets/b5ff6495-4910-4253-bdaa-12d07fce467f" />
<img width="1467" alt="Screenshot 2025-01-28 at 09 39 06" src="https://github.com/user-attachments/assets/c01aacb5-6015-41f7-b024-ba0ded69c15d" />
<img width="1467" alt="Screenshot 2025-01-28 at 09 39 16" src="https://github.com/user-attachments/assets/25542cde-bc6d-4c72-b872-b11e6c184f92" />

## Second test

Test the default from the template. To achieve this I used the schedule define as:
```yaml
cleanupJob:
  enabled: true
  clean_variable_cli_args: ""
  clean_log_cli_args: ""
```

<img width="1467" alt="Screenshot 2025-01-28 at 09 40 23" src="https://github.com/user-attachments/assets/c633e83d-e64a-4988-9bfc-77eee2eba855" />
