### PR TITLE
Add private registry controls for redis/postgres initContainers

### DIFF
--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -30,7 +30,12 @@ spec:
       initContainers:
         {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
         - name: wait-for-redis
-          image: alpine
+          {{- if .Values.image.redisWait.digest }}
+          image: "{{ .Values.image.redisWait.repository }}@{{ .Values.image.redisWait.digest }}"
+          {{- else }}
+          image: "{{ .Values.image.redisWait.repository }}:{{ .Values.image.redisWait.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
@@ -43,7 +48,12 @@ spec:
         {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: wait-for-postgres
-          image: busybox
+          {{- if .Values.image.postgresWait.digest }}
+          image: "{{ .Values.image.postgresWait.repository }}@{{ .Values.image.postgresWait.digest }}"
+          {{- else }}
+          image: "{{ .Values.image.postgresWait.repository }}:{{ .Values.image.postgresWait.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ .Values.postgresql.fullnameOverride }} 5432; do echo waiting for postgres; sleep 2; done;']
         {{- end }}
       {{- end }}

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -30,7 +30,12 @@ spec:
       initContainers:
         {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
         - name: wait-for-redis
-          image: alpine
+          {{- if .Values.image.redisWait.digest }}
+          image: "{{ .Values.image.redisWait.repository }}@{{ .Values.image.redisWait.digest }}"
+          {{- else }}
+          image: "{{ .Values.image.redisWait.repository }}:{{ .Values.image.redisWait.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
@@ -43,7 +48,12 @@ spec:
         {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: wait-for-postgres
-          image: busybox
+          {{- if .Values.image.postgresWait.digest }}
+          image: "{{ .Values.image.postgresWait.repository }}@{{ .Values.image.postgresWait.digest }}"
+          {{- else }}
+          image: "{{ .Values.image.postgresWait.repository }}:{{ .Values.image.postgresWait.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ .Values.postgresql.fullnameOverride }} 5432; do echo waiting for postgres; sleep 2; done;']
         {{- end }}
       {{- end }}

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -30,7 +30,12 @@ spec:
       initContainers:
         {{- if or .Values.redis.enabled .Values.redis.customRedisURL }}
         - name: wait-for-redis
-          image: alpine
+          {{- if .Values.image.redisWait.digest }}
+          image: "{{ .Values.image.redisWait.repository }}@{{ .Values.image.redisWait.digest }}"
+          {{- else }}
+          image: "{{ .Values.image.redisWait.repository }}:{{ .Values.image.redisWait.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           {{- if .Values.redis.enabled }}
             - name: REDIS_URL
@@ -43,7 +48,12 @@ spec:
         {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: wait-for-postgres
-          image: busybox
+          {{- if .Values.image.postgresWait.digest }}
+          image: "{{ .Values.image.postgresWait.repository }}@{{ .Values.image.postgresWait.digest }}"
+          {{- else }}
+          image: "{{ .Values.image.postgresWait.repository }}:{{ .Values.image.postgresWait.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ .Values.postgresql.fullnameOverride }} 5432; do echo waiting for postgres; sleep 2; done;']
         {{- end }}
       {{- end }}

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -64,10 +64,19 @@ redis:
   customRedisURL: ""
 
 image:
+  redisWait:
+    repository: alpine
+    tag: latest
+    digest: ""
+  postgresWait:
+    repository: busybox
+    tag: latest
+    digest: ""
   repository: mageai/mageai
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  digest: ""
 
 imagePullSecrets: []
 nameOverride: "mageai"


### PR DESCRIPTION
# Summary

When redis and/or postgres is enabled, the initContainers used to wait for the availability of these services have hardcoded images/tags. This can lead to policy violations when images must be pulled from a private registry and when explicit tags/digests must be used.

The present PR adds the ability to control the image repository,tag and digest in the same way as is done for the main mageai container, for the standalone deployment, webserver and scheduler. Additionally the digest value is added for all images in the values file, so it is clear it can be configured.

The default values are:
```yaml
image:
  redisWait:
    repository: alpine
    tag: latest
    digest: ""
  postgresWait:
    repository: busybox
    tag: latest
    digest: ""
  repository: mageai/mageai
  pullPolicy: Always
  # Overrides the image tag whose default is the chart appVersion.
  tag: ""
  digest: ""
```
And can be overridden like so:

```yaml
image:
  redisWait:
    repository: sample.private-registry.com/alpine
    tag: 3.21.3
    digest: ""
  postgresWait:
    repository: sample.private-registry.com/busybox
    tag: 1.37.0
    digest: sha256:42279ede3600b4e63af075a5e27d68232ff837d9cdcaba74feffc7ab0dfec0dc
```

# Tests

The following values overrides were used to template the chart with `helm template`:
```yaml
redis:
  enabled: true
postgresql:
  enabled: true
replicaCount: 3
standaloneScheduler: true
scheduelr:
  replicaCount: 3
webserver:
  replicaCount: 3
image:
  redisWait:
    repository: sample.private-registry.com/alpine
    tag: 3.21.3
    digest: ""
  postgresWait:
    repository: sample.private-registry.com/busybox
    tag: 1.37.0
    digest: sha256:42279ede3600b4e63af075a5e27d68232ff837d9cdcaba74feffc7ab0dfec0dc
```

And the following can be seen from the output for the scheduler, where both redis and postgres initContainer images are sourced from the private registry, with the redis one using a fixed tag and the postgres one using a digest:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: mageai-scheduler
  labels:
    helm.sh/chart: mageai-0.2.10
    app.kubernetes.io/name: mageai
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.9.74"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: mageai-scheduler
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: mageai-scheduler
        app.kubernetes.io/instance: release-name
    spec:
      serviceAccountName: mageai
      securityContext:
        {}
      initContainers:
        - name: wait-for-redis
          image: "sample.private-registry.com/alpine:3.21.3"
          imagePullPolicy: Always
          env:
            - name: REDIS_URL
              value: redis://release-name-redis-headless:6379/0
          command: ["sh", "-c", "until nc -z -v $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f1) $(echo $REDIS_URL | cut -d'/' -f3 | cut -d':' -f2); do sleep 1; done"]
        - name: wait-for-postgres
          image: "sample.private-registry.com/busybox@sha256:42279ede3600b4e63af075a5e27d68232ff837d9cdcaba74feffc7ab0dfec0dc"
          imagePullPolicy: Always
          command: ['sh', '-c', 'until nc -z postgresql-service 5432; do echo waiting for postgres; sleep 2; done;']
      containers:
        - name: mageai
          securityContext:
            {}
          image: "mageai/mageai:0.9.74"
          imagePullPolicy: Always
          ports:
            - name: http
              containerPort: 6789
              protocol: TCP
          resources:
            {}
          envFrom:
          env:
            - name: KUBE_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: REDIS_URL
              value: redis://release-name-redis-headless:6379/0
            - name: MAGE_DATABASE_CONNECTION_URL
              value: postgresql://your_username:your_password@postgresql-service:5432/your_database
            - name: INSTANCE_TYPE
              value: scheduler
          volumeMounts:
            - mountPath: /home/src
              name: mage-fs
      volumes:
        - hostPath:
            path: /path/to/mage_project
          name: mage-fs
```
