### PR TITLE
[xy] Use bitnamilegacy repository for postgresql and redis image.

### DIFF
--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -53,6 +53,11 @@ postgresql:
     username: your_username
     password: your_password
     database: your_database
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+    tag: 16.3.0-debian-12-r19
+    pullPolicy: IfNotPresent
 
 # Enable redis if you want more replica
 redis:
@@ -62,6 +67,11 @@ redis:
     enabled: false
   # Your custom redis url (make sure redis.enabled is set to false)
   customRedisURL: ""
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/redis
+    tag: 7.2.1-debian-11-r0
+    pullPolicy: IfNotPresent
 
 image:
   # The main Mage container image repository.


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Close: https://github.com/mage-ai/helm-charts/issues/81
This pull request updates the Helm chart configuration for MageAI to specify custom container images for both PostgreSQL and Redis. These changes improve control over the deployment by allowing explicit selection of image versions and registries.

**PostgreSQL image configuration:**
* Added the `image` section to `postgresql` with registry, repository, tag, and pull policy, specifying the use of `bitnamilegacy/postgresql:16.3.0-debian-12-r19` from Docker Hub.

**Redis image configuration:**
* Added the `image` section to `redis` with registry, repository, tag, and pull policy, specifying the use of `bitnamilegacy/redis:7.2.1-debian-11-r0` from Docker Hub.

# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
