### PR TITLE
Adding support for deploymentAnnotations from values.

### DIFF
--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mageai.fullname" . }}
-  {{- with .Values.DeploymentAnnotations }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
     {{- toYaml . | nindent 8 }}
   {{- end }}

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -110,6 +110,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "mageai"
 
+deploymentAnnotations: {}
+
 podAnnotations: {}
 
 podLabels: {}


### PR DESCRIPTION
# Summary
Some services needs annotations at deployment metadata.annotation level to work. For example, doppler. The chart currently supports podAnnotations only. 

# Tests
<!-- How did you test your change? -->

cc:
<!-- Optionally mention someone to let them know about this pull request -->
