### PR TITLE
[xy] Support workspace and k8s executor configs.

### DIFF
--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -35,7 +35,7 @@ apiVersion: v2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.78"
+appVersion: "0.9.79"
 
 description: A Helm chart for Mage AI
 
@@ -76,4 +76,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.13
+version: 0.2.14

--- a/charts/mageai/templates/configmap-k8s-executor.yaml
+++ b/charts/mageai/templates/configmap-k8s-executor.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.k8sExecutorConfig .Values.k8sExecutorConfig.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mageai.fullname" . }}-k8s-executor-config
+  labels:
+    {{- include "mageai.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.k8sExecutorConfig | nindent 4 }}
+{{- end }}

--- a/charts/mageai/templates/configmap-workspace-config.yaml
+++ b/charts/mageai/templates/configmap-workspace-config.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.workspaceConfig .Values.workspaceConfig.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mageai.fullname" . }}-workspace-config
+  labels:
+    {{- include "mageai.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.workspaceConfig | nindent 4 }}
+{{- end }}

--- a/charts/mageai/templates/configmap.yaml
+++ b/charts/mageai/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.config }}
+{{- if .Values.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,4 +7,4 @@ metadata:
     {{- include "mageai.labels" . | nindent 4 }}
 data:
   {{- toYaml .Values.config | nindent 2 }}
-{{ end }}
+{{- end }}

--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -124,12 +124,32 @@ spec:
             - name: MAGE_DATABASE_CONNECTION_URL
               value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Values.postgresql.fullnameOverride }}:5432/{{ .Values.postgresql.auth.database }}
           {{- end }}
+          {{- if and .Values.workspaceConfig .Values.workspaceConfig.enabled }}
+            - name: WORKSPACE_DEFAULT_CONFIG_PATH
+              value: /etc/mage/workspace-config.yaml
+          {{- end }}
+          {{- if and .Values.k8sExecutorConfig .Values.k8sExecutorConfig.enabled }}
+            - name: K8S_DEFAULT_CONFIG_PATH
+              value: /etc/mage/k8s-executor-config.yaml
+          {{- end }}
           volumeMounts:
           {{- if .Values.volumes }}
             - name: mage-fs
               mountPath: /home/src
           {{- else if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.workspaceConfig .Values.workspaceConfig.enabled }}
+            - name: workspace-config
+              mountPath: /etc/mage/workspace-config.yaml
+              subPath: config.yaml
+              readOnly: true
+          {{- end }}
+          {{- if and .Values.k8sExecutorConfig .Values.k8sExecutorConfig.enabled }}
+            - name: k8s-executor-config
+              mountPath: /etc/mage/k8s-executor-config.yaml
+              subPath: config.yaml
+              readOnly: true
           {{- end }}
         {{- if .Values.extraContainers }}
           {{- toYaml .Values.extraContainers | nindent 8 }}
@@ -151,5 +171,15 @@ spec:
         {{- toYaml .Values.volumes | nindent 8 }}
       {{- else if .Values.extraVolumes -}}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.workspaceConfig .Values.workspaceConfig.enabled }}
+        - name: workspace-config
+          configMap:
+            name: {{ include "mageai.fullname" . }}-workspace-config
+      {{- end }}
+      {{- if and .Values.k8sExecutorConfig .Values.k8sExecutorConfig.enabled }}
+        - name: k8s-executor-config
+          configMap:
+            name: {{ include "mageai.fullname" . }}-k8s-executor-config
       {{- end }}
 {{- end }}

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -94,12 +94,32 @@ spec:
           {{- end }}
             - name: INSTANCE_TYPE
               value: scheduler
+          {{- if and .Values.workspaceConfig .Values.workspaceConfig.enabled }}
+            - name: WORKSPACE_DEFAULT_CONFIG_PATH
+              value: /etc/mage/workspace-config.yaml
+          {{- end }}
+          {{- if and .Values.k8sExecutorConfig .Values.k8sExecutorConfig.enabled }}
+            - name: K8S_DEFAULT_CONFIG_PATH
+              value: /etc/mage/k8s-executor-config.yaml
+          {{- end }}
           volumeMounts:
           {{- if .Values.volumes }}
             - name: mage-fs
               mountPath: /home/src
           {{- else if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.workspaceConfig .Values.workspaceConfig.enabled }}
+            - name: workspace-config
+              mountPath: /etc/mage/workspace-config.yaml
+              subPath: config.yaml
+              readOnly: true
+          {{- end }}
+          {{- if and .Values.k8sExecutorConfig .Values.k8sExecutorConfig.enabled }}
+            - name: k8s-executor-config
+              mountPath: /etc/mage/k8s-executor-config.yaml
+              subPath: config.yaml
+              readOnly: true
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -118,5 +138,15 @@ spec:
         {{- toYaml .Values.volumes | nindent 8 }}
       {{- else if .Values.extraVolumes -}}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.workspaceConfig .Values.workspaceConfig.enabled }}
+        - name: workspace-config
+          configMap:
+            name: {{ include "mageai.fullname" . }}-workspace-config
+      {{- end }}
+      {{- if and .Values.k8sExecutorConfig .Values.k8sExecutorConfig.enabled }}
+        - name: k8s-executor-config
+          configMap:
+            name: {{ include "mageai.fullname" . }}-k8s-executor-config
       {{- end }}
 {{- end }}

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -122,12 +122,32 @@ spec:
           {{- end }}
             - name: INSTANCE_TYPE
               value: web_server
+          {{- if and .Values.workspaceConfig .Values.workspaceConfig.enabled }}
+            - name: WORKSPACE_DEFAULT_CONFIG_PATH
+              value: /etc/mage/workspace-config.yaml
+          {{- end }}
+          {{- if and .Values.k8sExecutorConfig .Values.k8sExecutorConfig.enabled }}
+            - name: K8S_DEFAULT_CONFIG_PATH
+              value: /etc/mage/k8s-executor-config.yaml
+          {{- end }}
           volumeMounts:
           {{- if .Values.volumes }}
             - name: mage-fs
               mountPath: /home/src
           {{- else if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.workspaceConfig .Values.workspaceConfig.enabled }}
+            - name: workspace-config
+              mountPath: /etc/mage/workspace-config.yaml
+              subPath: config.yaml
+              readOnly: true
+          {{- end }}
+          {{- if and .Values.k8sExecutorConfig .Values.k8sExecutorConfig.enabled }}
+            - name: k8s-executor-config
+              mountPath: /etc/mage/k8s-executor-config.yaml
+              subPath: config.yaml
+              readOnly: true
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -146,5 +166,15 @@ spec:
         {{- toYaml .Values.volumes | nindent 8 }}
       {{- else if .Values.extraVolumes -}}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.workspaceConfig .Values.workspaceConfig.enabled }}
+        - name: workspace-config
+          configMap:
+            name: {{ include "mageai.fullname" . }}-workspace-config
+      {{- end }}
+      {{- if and .Values.k8sExecutorConfig .Values.k8sExecutorConfig.enabled }}
+        - name: k8s-executor-config
+          configMap:
+            name: {{ include "mageai.fullname" . }}-k8s-executor-config
       {{- end }}
 {{- end }}

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -300,6 +300,7 @@ cleanupJob:
 # Sets WORKSPACE_DEFAULT_CONFIG_PATH env var for the Mage application.
 workspaceConfig:
   enabled: false
+  # Whether to enforce the default config when it's conflicted with the user config
   enforce: false
 
   container_config:
@@ -331,6 +332,7 @@ workspaceConfig:
 # Sets K8S_DEFAULT_CONFIG_PATH env var for the Mage application.
 k8sExecutorConfig:
   enabled: false
+  # Whether to enforce the default config when it's conflicted with the user config
   enforce: false
 
   # Resource limits for executor pods

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -2,10 +2,17 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# ------------------------------------------------------------------------------
+# Deployment topology
+# ------------------------------------------------------------------------------
+
+# Number of Mage replicas to run (when standaloneScheduler is false)
 replicaCount: 1
+
+# When true, splits Mage into separate web server and scheduler deployments for scaling
 standaloneScheduler: false
 
-# Effective if standaloneScheduler is true
+# Scheduler deployment settings (only used when standaloneScheduler is true)
 scheduler:
   replicaCount: 1
   name: mageai-scheduler
@@ -25,7 +32,7 @@ scheduler:
   #   maxReplicas: 10
   #   targetCPUUtilizationPercentage: 50
 
-# Effective if standaloneScheduler is true
+# Web server deployment settings (only used when standaloneScheduler is true)
 webServer:
   replicaCount: 1
   name: mageai-webserver
@@ -45,7 +52,11 @@ webServer:
   #   maxReplicas: 10
   #   targetCPUUtilizationPercentage: 50
 
-# Enable Postgres as the DB
+# ------------------------------------------------------------------------------
+# Dependencies
+# ------------------------------------------------------------------------------
+
+# PostgreSQL database for Mage metadata and pipeline state
 postgresql:
   enabled: false
   fullnameOverride: "postgresql-service"
@@ -59,7 +70,7 @@ postgresql:
     tag: 16.3.0-debian-12-r19
     pullPolicy: IfNotPresent
 
-# Enable redis if you want more replica
+# Redis for distributed locking and caching (required for multiple replicas)
 redis:
   enabled: false
   architecture: standalone
@@ -90,6 +101,7 @@ image:
 #   - name: my-private-registry-secret
 imagePullSecrets: []
 
+# Lightweight images for init containers (Redis/PostgreSQL readiness checks)
 initContainerImages:
   # Image used in initContainers for Redis readiness check.
   # Default is public Docker Hub Alpine image.
@@ -98,7 +110,13 @@ initContainerImages:
   # Default is public Docker Hub BusyBox image.
   busybox: busybox
 
+# ------------------------------------------------------------------------------
+# Naming and RBAC
+# ------------------------------------------------------------------------------
+
+# Override the chart name in resource names
 nameOverride: "mageai"
+# Override the full name of resources (takes precedence over nameOverride)
 fullnameOverride: "mageai"
 
 serviceAccount:
@@ -110,12 +128,16 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "mageai"
 
+# Annotations to add to the Deployment
 deploymentAnnotations: {}
 
+# Annotations to add to pods
 podAnnotations: {}
 
+# Labels to add to pods
 podLabels: {}
 
+# Security context for the pod
 podSecurityContext: {}
   # fsGroup: 2000
 
@@ -127,14 +149,21 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# ------------------------------------------------------------------------------
+# Service and networking
+# ------------------------------------------------------------------------------
+
 service:
   type: LoadBalancer
   port: 6789
-  # Annotations to add to the service
+  # Annotations to add to the service (e.g., for cloud load balancers)
   annotations: {}
 
-# Configure extra options for containers' liveness probes
-# If not configured, the probe is enabled using the following values
+# ------------------------------------------------------------------------------
+# Health checks
+# ------------------------------------------------------------------------------
+
+# Liveness probe configuration
 livenessProbe:
   enabled: true
   path: /api/status
@@ -146,8 +175,7 @@ livenessProbe:
   # terminationGracePeriodSeconds:
   timeoutSeconds: 10
 
-# Configure extra options for containers' readiness probes
-# If not configured, the probe is enabled using the following values
+# Readiness probe configuration
 readinessProbe:
   enabled: true
   path: /api/status
@@ -159,18 +187,19 @@ readinessProbe:
   # terminationGracePeriodSeconds:
   timeoutSeconds: 1
 
-# Custom liveness probe
+# Override with a fully custom liveness probe (replaces default when set)
 customLivenessProbe: {}
 
-# Custom readiness probe
+# Override with a fully custom readiness probe (replaces default when set)
 customReadinessProbe: {}
 
-# Horizontal pod autoscaler
+# Horizontal Pod Autoscaler for the main deployment
 # hpa:
 #   minReplicas: 1
 #   maxReplicas: 10
 #   targetCPUUtilizationPercentage: 50
 
+# Ingress for external access
 # We recommend creating the ingress separately instead of creating it using this chart.
 # There is a corresponding Mage-Ingress chart to create an ingress for Mage if needed.
 # This section is kept here for backwards compatibility.
@@ -202,21 +231,31 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# Schedule pods only on nodes with these labels
 nodeSelector: {}
 
+# Allow pods to be scheduled on tainted nodes
 tolerations: []
 
+# Pod affinity/anti-affinity rules
 affinity: {}
 
+# ------------------------------------------------------------------------------
+# Storage and volumes
+# ------------------------------------------------------------------------------
+
+# Additional volume mounts for the Mage container
 extraVolumeMounts:
   - name: mage-fs
     mountPath: /home/src
 
+# Additional volumes (must include mage-fs for project code when not using persistence)
 extraVolumes:
   - name: mage-fs
     hostPath:
       path: /path/to/mage_project
 
+# Persistent volume for project storage (replaces hostPath when enabled)
 persistence:
   enabled: false
   storageClassName: storage-class-name
@@ -225,25 +264,85 @@ persistence:
   #   driver: efs.csi.aws.com
   #   volumeHandle: fs-0123456789
 
-# config: Default configuration for mageai as environment variables. These get injected directly in the container.
+# ------------------------------------------------------------------------------
+# Environment and configuration
+# ------------------------------------------------------------------------------
+
+# Environment variables injected into the Mage container (key-value pairs)
 config: {}
 
-# existingSecret: Specifies an existing secret to be used as environment variables. These get injected directly in the container.
+# Name of an existing Secret to use for environment variables (overrides secrets if both set)
 existingSecret: ""
 
-# secrets: Default secrets for mageai as environment variables. These get injected directly in the container.
-# Consider using a secret manager first, before sourcing secrets as environment variables.
+# Secrets to create and inject as environment variables (prefer a secret manager in production)
 secrets: {}
 
-# extraEnvs: Extra environment variables
+# Additional environment variables (supports valueFrom for field refs, etc.)
 extraEnvs:
   - name: KUBE_NAMESPACE
     valueFrom:
       fieldRef:
         fieldPath: metadata.namespace
 
+# CronJob for cleaning up old pipeline runs and logs
 cleanupJob:
   enabled: false
   clean_variable_cli_args: ""
   clean_log_cli_args: ""
   schedule_cron: "0 * * * *"  # Runs every hour
+
+# ------------------------------------------------------------------------------
+# Mage Pro features (workspaces and Kubernetes executor)
+# ------------------------------------------------------------------------------
+
+# Default workspace configuration for Mage Pro workspaces.
+# When enabled, creates a ConfigMap and mounts it at /etc/mage/workspace-config.yaml.
+# Sets WORKSPACE_DEFAULT_CONFIG_PATH env var for the Mage application.
+workspaceConfig:
+  enabled: false
+  enforce: false
+
+  # Resource limits and requests for workspace containers
+  resources:
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+    requests:
+      cpu: "1"
+      memory: "2Gi"
+
+  # nodeSelector:
+  #   node.kubernetes.io/instance-type: "m5.large"
+
+  # tolerations:
+  #   - key: "dedicated"
+  #     operator: "Equal"
+  #     value: "mage"
+  #     effect: "NoSchedule"
+
+# Default Kubernetes executor configuration for pipeline blocks.
+# When enabled, creates a ConfigMap and mounts it at /etc/mage/k8s-executor-config.yaml.
+# Sets K8S_DEFAULT_CONFIG_PATH env var for the Mage application.
+k8sExecutorConfig:
+  enabled: false
+  enforce: false
+
+  # Resource limits for executor pods
+  resourceLimits:
+    cpu: "2000m"
+    memory: "8Gi"
+
+  # Resource requests for executor pods
+  resourceRequests:
+    cpu: "1000m"
+    memory: "4Gi"
+
+  # Pod-level scheduling (nodeSelector, tolerations, affinity)
+  # pod:
+  #   nodeSelector:
+  #     workload: "data"
+  #   tolerations:
+  #     - key: "workload"
+  #       operator: "Equal"
+  #       value: "data"
+  #       effect: "NoSchedule"

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -302,23 +302,29 @@ workspaceConfig:
   enabled: false
   enforce: false
 
-  # Resource limits and requests for workspace containers
-  resources:
-    limits:
-      cpu: "2"
-      memory: "4Gi"
-    requests:
-      cpu: "1"
-      memory: "2Gi"
+  container_config:
+    # Resource limits and requests for workspace containers
+    resources:
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+      requests:
+        cpu: "1"
+        memory: "2Gi"
 
-  # nodeSelector:
-  #   node.kubernetes.io/instance-type: "m5.large"
+  #   nodeSelector:
+  #     node.kubernetes.io/instance-type: "m5.large"
 
-  # tolerations:
-  #   - key: "dedicated"
-  #     operator: "Equal"
-  #     value: "mage"
-  #     effect: "NoSchedule"
+  #   tolerations:
+  #     - key: "dedicated"
+  #       operator: "Equal"
+  #       value: "mage"
+  #       effect: "NoSchedule"
+  # lifecycle_config:
+  #   post_start:
+  #     command: echo "Hello World"
+  # service_account_name: workspace_config
+
 
 # Default Kubernetes executor configuration for pipeline blocks.
 # When enabled, creates a ConfigMap and mounts it at /etc/mage/k8s-executor-config.yaml.
@@ -328,12 +334,12 @@ k8sExecutorConfig:
   enforce: false
 
   # Resource limits for executor pods
-  resourceLimits:
+  resource_limits:
     cpu: "2000m"
     memory: "8Gi"
 
   # Resource requests for executor pods
-  resourceRequests:
+  resource_requests:
     cpu: "1000m"
     memory: "4Gi"
 

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -296,8 +296,8 @@ cleanupJob:
 # ------------------------------------------------------------------------------
 
 # Default workspace configuration for Mage Pro workspaces.
-# When enabled, creates a ConfigMap and mounts it at /etc/mage/workspace-config.yaml.
-# Sets WORKSPACE_DEFAULT_CONFIG_PATH env var for the Mage application.
+# When enabled, creates a ConfigMap and mounts it at /etc/mage/workspace-config.yaml,
+# and sets the WORKSPACE_DEFAULT_CONFIG_PATH environment variable to point to this file.
 workspaceConfig:
   enabled: false
   # Whether to enforce the default config when it's conflicted with the user config
@@ -328,8 +328,8 @@ workspaceConfig:
 
 
 # Default Kubernetes executor configuration for pipeline blocks.
-# When enabled, creates a ConfigMap and mounts it at /etc/mage/k8s-executor-config.yaml.
-# Sets K8S_DEFAULT_CONFIG_PATH env var for the Mage application.
+# When enabled, creates a ConfigMap and mounts it at /etc/mage/k8s-executor-config.yaml,
+# and sets the K8S_DEFAULT_CONFIG_PATH environment variable to point to this file.
 k8sExecutorConfig:
   enabled: false
   # Whether to enforce the default config when it's conflicted with the user config


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
This pull request enhances the MageAI Helm chart by introducing support for advanced configuration of Mage Pro features (workspaces and Kubernetes executor), improving documentation and organization of the `values.yaml`, and ensuring proper mounting and injection of configuration files and environment variables across deployments. The changes make it easier to manage complex deployments and provide more flexibility for production setups.

Key changes include:

**Mage Pro Features: Workspace and Kubernetes Executor Configuration**
* Added `workspaceConfig` and `k8sExecutorConfig` sections to `values.yaml`, allowing users to enable, configure, and mount default workspace and Kubernetes executor configs via ConfigMaps. These are automatically injected as environment variables and mounted in the appropriate containers when enabled. [[1]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aL228-R348) [[2]](diffhunk://#diff-87be9e4ce118c66027e92783b9c600cecc303309ad5dcefe58105ecd6955ff42R127-R153) [[3]](diffhunk://#diff-87be9e4ce118c66027e92783b9c600cecc303309ad5dcefe58105ecd6955ff42R175-R184) [[4]](diffhunk://#diff-5b46d8a7f7db0ac908dd857db523c25888576cfd5863f71f554447ad01c374f7R97-R123) [[5]](diffhunk://#diff-5b46d8a7f7db0ac908dd857db523c25888576cfd5863f71f554447ad01c374f7R142-R151) [[6]](diffhunk://#diff-800d3c407e3cd3db2f6db3fc1f9f0122584b3da8e3351b1129e849c8801295a3R125-R151) [[7]](diffhunk://#diff-800d3c407e3cd3db2f6db3fc1f9f0122584b3da8e3351b1129e849c8801295a3R170-R179)

**Deployment and Pod Customization**
* Introduced new options in `values.yaml` for pod annotations, labels, security context, nodeSelector, tolerations, and affinity, providing finer control over pod scheduling and security. [[1]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aR131-R140) [[2]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aR234-R258)

**Improved Documentation and Organization**
* Restructured `values.yaml` with clear section headers and expanded inline documentation, making configuration options easier to discover and understand. [[1]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aR5-R15) [[2]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aL48-R59) [[3]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aL62-R73) [[4]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aR104) [[5]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aR113-R119) [[6]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aR152-R166) [[7]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aL149-R178) [[8]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aL162-R202) [[9]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aL228-R348)

**ConfigMap Template Improvements**
* Fixed Helm template whitespace handling in `configmap.yaml` for more consistent rendering. [[1]](diffhunk://#diff-80c9aad4872ddcd0abfbc96bfc682479298419ccd0827ff830599a119fa616acL1-R1) [[2]](diffhunk://#diff-80c9aad4872ddcd0abfbc96bfc682479298419ccd0827ff830599a119fa616acL10-R10)

**Service and Health Probe Enhancements**
* Clarified service annotations and improved health probe configuration options for liveness and readiness, including support for custom probes. [[1]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aR152-R166) [[2]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aL149-R178) [[3]](diffhunk://#diff-424876dcd13ddb89d9003a169cff4cb28205d4fb16010b42a6e73f51de2ff29aL162-R202)


# Tests
<!-- How did you test your change? -->
tested locally

cc:
<!-- Optionally mention someone to let them know about this pull request -->
