### PR TITLE
feat(mageai): add per-component scheduling overrides for standaloneSc…

### DIFF
--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -12,14 +12,19 @@ spec:
       {{- include "mageai.schedulerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if .Values.scheduler.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.scheduler.podAnnotations | nindent 8 }}
+      {{- else if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
         {{- include "mageai.schedulerSelectorLabels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.scheduler.podLabels }}
+        {{- toYaml .Values.scheduler.podLabels | nindent 8 }}
+        {{- else if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -121,17 +126,26 @@ spec:
               subPath: config.yaml
               readOnly: true
           {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- if .Values.scheduler.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.scheduler.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if .Values.scheduler.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.scheduler.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- if .Values.scheduler.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.scheduler.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       volumes:
       {{- if .Values.volumes }}

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -12,14 +12,19 @@ spec:
       {{- include "mageai.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if .Values.webServer.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.webServer.podAnnotations | nindent 8 }}
+      {{- else if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
         {{- include "mageai.selectorLabels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.webServer.podLabels }}
+        {{- toYaml .Values.webServer.podLabels | nindent 8 }}
+        {{- else if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -149,17 +154,26 @@ spec:
               subPath: config.yaml
               readOnly: true
           {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- if .Values.webServer.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.webServer.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if .Values.webServer.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.webServer.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- if .Values.webServer.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.webServer.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       volumes:
       {{- if .Values.volumes }}

--- a/charts/mageai/values.yaml
+++ b/charts/mageai/values.yaml
@@ -31,6 +31,16 @@ scheduler:
   #   minReplicas: 1
   #   maxReplicas: 10
   #   targetCPUUtilizationPercentage: 50
+  # Overrides global nodeSelector for the scheduler pod
+  nodeSelector: {}
+  # Overrides global tolerations for the scheduler pod
+  tolerations: []
+  # Overrides global affinity for the scheduler pod
+  affinity: {}
+  # Overrides global podAnnotations for the scheduler pod
+  podAnnotations: {}
+  # Overrides global podLabels for the scheduler pod
+  podLabels: {}
 
 # Web server deployment settings (only used when standaloneScheduler is true)
 webServer:
@@ -51,6 +61,16 @@ webServer:
   #   minReplicas: 1
   #   maxReplicas: 10
   #   targetCPUUtilizationPercentage: 50
+  # Overrides global nodeSelector for the webserver pod
+  nodeSelector: {}
+  # Overrides global tolerations for the webserver pod
+  tolerations: []
+  # Overrides global affinity for the webserver pod
+  affinity: {}
+  # Overrides global podAnnotations for the webserver pod
+  podAnnotations: {}
+  # Overrides global podLabels for the webserver pod
+  podLabels: {}
 
 # ------------------------------------------------------------------------------
 # Dependencies


### PR DESCRIPTION
…heduler

Add nodeSelector, tolerations, affinity, podAnnotations, and podLabels to scheduler and webServer with fallback to global values when not set.

# Summary
<!-- Brief summary of what your code does -->
When `standaloneScheduler` is true, the scheduler and webserver pods now support
their own `nodeSelector`, `tolerations`, `affinity`, `podAnnotations`, and `podLabels`.
If not set, they fall back to the global values — no breaking change.

# Tests
<!-- How did you test your change? -->
Manually verified with `helm template` that:
- omitting per-component values renders the global ones
- setting per-component values overrides the global ones
- setting neither renders no scheduling fields

cc:
<!-- Optionally mention someone to let them know about this pull request -->
