### PR TITLE
Add checksum annotations to trigger rollout on config/secret changes

### DIFF
--- a/charts/mageai/templates/deployment.yaml
+++ b/charts/mageai/templates/deployment.yaml
@@ -16,9 +16,17 @@ spec:
       {{- include "mageai.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.config .Values.secrets }}
       annotations:
+        {{- if .Values.config }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
+        {{- end }}
+        {{- if and (not .Values.existingSecret) .Values.secrets }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "mageai.selectorLabels" . | nindent 8 }}

--- a/charts/mageai/templates/scheduler.yaml
+++ b/charts/mageai/templates/scheduler.yaml
@@ -12,9 +12,17 @@ spec:
       {{- include "mageai.schedulerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.config .Values.secrets }}
       annotations:
+        {{- if .Values.config }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
+        {{- end }}
+        {{- if and (not .Values.existingSecret) .Values.secrets }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "mageai.schedulerSelectorLabels" . | nindent 8 }}

--- a/charts/mageai/templates/webservice.yaml
+++ b/charts/mageai/templates/webservice.yaml
@@ -12,9 +12,17 @@ spec:
       {{- include "mageai.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.config .Values.secrets }}
       annotations:
+        {{- if .Values.config }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
+        {{- end }}
+        {{- if and (not .Values.existingSecret) .Values.secrets }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "mageai.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
Add checksum annotations to deployment, webservice, and scheduler pod templates so that pods automatically restart on ConfigMap or Secret changes. Follows the official Helm rolling deployment pattern.

# Tests
<!-- How did you test your change? -->
- Ran `helm template` and verified checksum annotations appear in pod templates
- Confirmed annotations are omitted when config and secrets are not set

cc:
<!-- Optionally mention someone to let them know about this pull request -->
