### PR TITLE
Add pods log permission to service account

### DIFF
--- a/charts/mageai/templates/serviceaccount.yaml
+++ b/charts/mageai/templates/serviceaccount.yaml
@@ -20,6 +20,9 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs", "jobs/status"]
   verbs: ["create", "delete", "get"]


### PR DESCRIPTION
## Summary
- grant the Mage service account get access to the pods/log subresource
- keep existing pod and job manager permissions unchanged

## Tests
- helm template mageai charts/mageai