### PR TITLE
Bump Helm chart version to 0.2.15

### DIFF
--- a/charts/mageai/Chart.yaml
+++ b/charts/mageai/Chart.yaml
@@ -76,4 +76,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.14
+version: 0.2.15


### PR DESCRIPTION
## Summary
- Bump the mageai Helm chart version to 0.2.15

## Tests
- Not run (metadata-only chart version bump)